### PR TITLE
Emacs starts before gpg has detected hardware secrets

### DIFF
--- a/nixpkgs/configurations/tty-programs/emacs.nix
+++ b/nixpkgs/configurations/tty-programs/emacs.nix
@@ -35,5 +35,6 @@
       enable = true;
       arguments = [ "--no-wait" "--create-frame" ];
     };
+    socketActivation.enable = true;
   };
 }


### PR DESCRIPTION
On some devices, `gpg --card-status` needs to be run before gpg will use hardware secrets.

This currently needs to be done manually, and in turn causes emacs to not realize these secrets are available.