### PR TITLE
Add nixfmt to the default packages

### DIFF
--- a/dotfiles/emacs.d/config/file-types.el
+++ b/dotfiles/emacs.d/config/file-types.el
@@ -80,7 +80,8 @@
 
 (use-package nix-mode
   :mode ("\\.nix\\'")
-  :bind ("C-c f" . nix-format-buffer))
+  :bind (:map nix-mode-map
+              ("C-c f" . nix-format-buffer)))
 
 (use-package stumpwm-mode)
 

--- a/nixpkgs/configurations/tty-programs/default.nix
+++ b/nixpkgs/configurations/tty-programs/default.nix
@@ -3,7 +3,13 @@
 {
   imports = [ ./emacs.nix ./mail ./mail/personal.nix ./zsh.nix ];
 
-  home.packages = with pkgs; [ any-nix-shell pass screen tree ];
+  home.packages = with pkgs; [
+    any-nix-shell
+    nixfmt # *.nix files are used to pull in project deps, so we always need this
+    pass
+    screen
+    tree
+  ];
 
   home.file = {
     ".profile".source = "${dotroot}/dotfiles/env";


### PR DESCRIPTION
I use `nixfmt` absolutely everywhere and it's really not right to pull
it in as a project dependency, especially when upstream doesn't use a
flake.

Fixes #20.