### PR TITLE
Don't abuse propagatedBuildInputs

### DIFF
--- a/dotfiles/bin/dump-ics
+++ b/dotfiles/bin/dump-ics
@@ -1,5 +1,4 @@
-#!/usr/bin/env nix-shell
-#! nix-shell -i python -p python38 python38Packages.ics
+#!/usr/bin/env python3
 
 import sys
 

--- a/nixpkgs/configurations/graphical-programs/default.nix
+++ b/nixpkgs/configurations/graphical-programs/default.nix
@@ -8,7 +8,6 @@
     feh
     llpp
     rofi
-    scrot
     xsel
 
     local.cap

--- a/nixpkgs/pkgs/background.nix
+++ b/nixpkgs/pkgs/background.nix
@@ -1,6 +1,6 @@
 { stdenv, feh, makeWrapper }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "background";
   version = "1.0";
   src = ../../dotfiles/bin;
@@ -8,5 +8,10 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     install background $out/bin
   '';
-  propagatedBuildInputs = [ feh ];
+  nativeBuildInputs = [ makeWrapper ];
+  wrapperPath = with stdenv.lib; makeBinPath [ feh ];
+  postFixup = ''
+    wrapProgram $out/bin/background \
+        --prefix PATH : "${wrapperPath}"
+  '';
 }

--- a/nixpkgs/pkgs/cap.nix
+++ b/nixpkgs/pkgs/cap.nix
@@ -1,6 +1,6 @@
 { stdenv, scrot, xorg, makeWrapper }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "cap";
   version = "1.0";
   src = ../../dotfiles/bin;
@@ -8,5 +8,10 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     install cap $out/bin
   '';
-  propagatedBuildInputs = [ scrot xorg.xprop ];
+  nativeBuildInputs = [ makeWrapper ];
+  wrapperPath = with stdenv.lib; makeBinPath [ scrot xorg.xprop ];
+  postFixup = ''
+    wrapProgram $out/bin/cap \
+        --prefix PATH : "${wrapperPath}"
+  '';
 }

--- a/nixpkgs/pkgs/dump-ics.nix
+++ b/nixpkgs/pkgs/dump-ics.nix
@@ -1,4 +1,4 @@
-{ stdenv, python38, python38Packages, ... }:
+{ stdenv, python3 }:
 
 stdenv.mkDerivation {
   pname = "dump-ics";
@@ -8,5 +8,5 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     install dump-ics $out/bin
   '';
-  propagatedBuildInputs = [ python38 python38Packages.ics ];
+  buildInputs = [ (python3.withPackages (pypkgs: with pypkgs; [ ics ])) ];
 }

--- a/nixpkgs/pkgs/read-sops.nix
+++ b/nixpkgs/pkgs/read-sops.nix
@@ -1,6 +1,6 @@
-{ stdenv, python3, sops }:
+{ stdenv, python3, sops, makeWrapper }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "read-sops";
   version = "1.0";
   src = ../../dotfiles/bin;
@@ -8,7 +8,12 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     install read-sops $out/bin
   '';
+  nativeBuildInputs = [ makeWrapper ];
+  wrapperPath = with stdenv.lib; makeBinPath [ sops ];
   buildInputs =
     [ (python3.withPackages (pypkgs: with pypkgs; [ xdg ruamel_yaml ])) ];
-  propagatedBuildInputs = [ sops ];
+  postFixup = ''
+    wrapProgram $out/bin/read-sops \
+        --prefix PATH : "${wrapperPath}"
+  '';
 }

--- a/nixpkgs/pkgs/zsh-background-notify.nix
+++ b/nixpkgs/pkgs/zsh-background-notify.nix
@@ -9,9 +9,16 @@ stdenv.mkDerivation {
     rev = "d5f0430cb052f82c433c17707816910da87e201e";
     sha256 = "0p8fk50bxr8kg2v72afg7f2n09n9ap0yn7gz1i78nd54l0wc041n";
   };
-  propagatedBuildInputs = [ libnotify ];
+
+  # FIXME: This breaks the notification-application detection
+  # "algorithm". Notably, since libnotify will always be "detected",
+  # kdialog/notifu will never work.
+  #
+  # It'd make more sense to add a final default implementation.
   installPhase = ''
     mkdir -p $out/
-    install bgnotify.plugin.zsh $out/
+    substitute bgnotify.plugin.zsh $out/bgnotify.plugin.zsh \
+        --replace 'hash notify-send' 'true' \
+        --replace 'notify-send' '${libnotify}/bin/notify-send'
   '';
 }


### PR DESCRIPTION
I was under the misconception that this inferred some runtime
dependency onto the packages specified - this turns out not to be
true.

This commit reworks all packages to correctly set their script PATHs.