### PR TITLE
Build emacs from unstable to avoid issues with csv-mode

### DIFF
--- a/nixpkgs/pkgs/default.nix
+++ b/nixpkgs/pkgs/default.nix
@@ -6,7 +6,8 @@ with pkgs;
   background = pkgs.callPackage ./background.nix { };
   cap = pkgs.callPackage ./cap.nix { };
   dump-ics = pkgs.callPackage ./dump-ics.nix { };
-  emacs = pkgs.callPackage ./emacs.nix { };
+  # FIXME: When 21.5 is stable, switch back to stable pkgs
+  emacs = unstable-pkgs.callPackage ./emacs.nix { };
   gauth = pkgs.callPackage ./gauth.nix { };
   gcs = unstable-pkgs.callPackage ./gcs.nix { };
   oh-my-zsh-emacs = pkgs.callPackage ./oh-my-zsh-emacs.nix { };


### PR DESCRIPTION
For some reason, the upstream sha of csv-mode changed. This results
in build failures for the nix package, since the source can no longer
be found.

For the time being, I'll just build emacs with unstable. This seems to
work fine, and side-steps this issue; when 21.5 lands I can presumably
move back.