### PR TITLE
firefox: Disable ^Q shortcut

### DIFF
--- a/nixpkgs/configurations/graphical-programs/firefox.nix
+++ b/nixpkgs/configurations/graphical-programs/firefox.nix
@@ -44,6 +44,7 @@
           false;
         "browser.newtabpage.pinned" = false;
         "browser.protections_panel.infoMessage.seen" = true;
+        "browser.quitShortcut.disabled" = true;
         "browser.shell.checkDefaultBrowser" = false;
         "browser.ssb.enabled" = true;
         "browser.toolbars.bookmarks.visibility" = "never";


### PR DESCRIPTION
This is the most poorly designed shortcut you can imagine, and simply
quits the whole browser session (with one keystroke, right next to the
ubiquitous ^W!).