### PR TITLE
Clean up flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,7 +17,9 @@
     },
     "home-manager": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1617824794,
@@ -36,16 +38,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1618015028,
-        "narHash": "sha256-TqbvZ53LVpPNTnVfaaHkvsdaUZTCD2AIX4zIjK+LYVQ=",
-        "owner": "NixOS",
+        "lastModified": 1617958586,
+        "narHash": "sha256-Nedx7LR1e8V5/AFhdAC2nGm1ttNCPIuNsZFk5x6HZXE=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6d5dc3f0e421b94c6c774fc7726b3e6d89f92224",
+        "rev": "a6847cb5460b47241eb35d1a6588652411642066",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixos-20.09",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-unstable": {
@@ -60,22 +64,6 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1617958586,
-        "narHash": "sha256-Nedx7LR1e8V5/AFhdAC2nGm1ttNCPIuNsZFk5x6HZXE=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "a6847cb5460b47241eb35d1a6588652411642066",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-20.09",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -99,7 +87,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "nurpkgs": "nurpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -9,14 +9,15 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = inputs:
+  outputs =
+    { nixpkgs, nixpkgs-unstable, home-manager, nurpkgs, flake-utils, ... }:
     let
       overlays = [
         (final: prev: {
-          unstable = import inputs.nixpkgs-unstable { system = prev.system; };
+          unstable = import nixpkgs-unstable { system = prev.system; };
         })
         (final: prev: { local = import ./nixpkgs/pkgs { pkgs = prev; }; })
-        inputs.nurpkgs.overlay
+        nurpkgs.overlay
       ];
       make-home = { username ? "tlater", homeDirectory ? "/home/${username}"
         , modules ? [ ] }: {
@@ -49,8 +50,8 @@
       };
     }
     # Set up a "dev shell" that will work on all architectures
-    // (inputs.flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = import inputs.nixpkgs { inherit overlays system; };
+    // (flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = import nixpkgs { inherit overlays system; };
       in {
         packages = import ./nixpkgs/pkgs { inherit pkgs; };
         devShell = pkgs.mkShell { buildInputs = with pkgs; [ nixfmt ]; };

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,6 @@
       homeConfigurations = {
         yui = make-home {
           modules = [
-            ./nixpkgs/configurations
             ./nixpkgs/configurations/graphical-programs
             ./nixpkgs/configurations/tty-programs
             ./nixpkgs/configurations/graphical-programs/games.nix
@@ -39,7 +38,6 @@
         };
         ct-lt-02052 = make-home {
           modules = [
-            ./nixpkgs/configurations
             ./nixpkgs/configurations/graphical-programs
             ./nixpkgs/configurations/tty-programs
             ./nixpkgs/configurations/tty-programs/work.nix

--- a/nixpkgs/configurations/default.nix
+++ b/nixpkgs/configurations/default.nix
@@ -1,5 +1,0 @@
-{ ... }:
-
-{
-  imports = [ ./xdg-settings.nix ];
-}

--- a/nixpkgs/default.nix
+++ b/nixpkgs/default.nix
@@ -3,6 +3,8 @@
 {
   _module.args.dotroot = ./..;
 
+  imports = [ ./configurations/xdg-settings.nix ];
+
   home.stateVersion = "20.09";
   programs.direnv = {
     enable = true;


### PR DESCRIPTION
The motivation is to make this installable with the new `--flake` cli
arg of home-manager, but it isn't quite ripe.

Nonetheless, the file was in dire need of cleanup, it was originally
written when I just started wrapping my head around flakes ;)