### PR TITLE
firefox: Add a couple more add-ons

### DIFF
--- a/nixpkgs/configurations/graphical-programs/firefox.nix
+++ b/nixpkgs/configurations/graphical-programs/firefox.nix
@@ -14,7 +14,11 @@
   programs.firefox = {
     enable = true;
     extensions = with pkgs.nur.repos.rycee.firefox-addons; [
+      buster-captcha-solver
+      clearurls
+      no-pdf-download
       react-devtools
+      reduxdevtools
       ublock-origin
     ];
     profiles."tlater" = {


### PR DESCRIPTION
Reasoning for each:

- buster-captcha-solver
  - More convenient than clicking images
- clearurls
  - Keeps me from pasting tracking gunk everywhere
- no-pdf-download
  - Solve annoying pdf downloads
- reduxdevtools
  - Always wanted this, recently packaged upstream

Also put in a packaging request for the translation add-on, because
apparently rycee accepts these :)

- https://gitlab.com/rycee/nur-expressions/-/issues/36