### PR TITLE
emacs: Use ripgrep and don't use helm for searching

### DIFF
--- a/dotfiles/emacs.d/config/packages.el
+++ b/dotfiles/emacs.d/config/packages.el
@@ -158,6 +158,9 @@
   :bind
   ("C-c d" . helm-dash))
 
+;; Ripgrep; used in projectile
+(use-package ripgrep)
+
 ;; Project browser
 (use-package projectile
   :functions (projectile-discover-projects-in-search-path)
@@ -180,10 +183,6 @@
   ([remap projectile-switch-project] . helm-projectile-switch-project)
   ([remap projectile-recentf] . helm-projectile-recentf)
   ([remap projectile-switch-to-buffer] . helm-projectile-switch-to-buffer)
-  ([remap projectile-grep] . helm-projectile-grep)
-  ([remap projectile-ack] . helm-projectile-ack)
-  ([remap projectile-ag] . helm-projectile-ag)
-  ([remap projectile-ripgrep] . helm-projectile-rg)
   ([remap projectile-browse-dirty-projects] . helm-projectile-browse-dirty-projects)
   :config
   (helm-projectile-on))

--- a/nixpkgs/configurations/tty-programs/default.nix
+++ b/nixpkgs/configurations/tty-programs/default.nix
@@ -6,6 +6,7 @@
   home.packages = with pkgs; [
     any-nix-shell
     nixfmt # *.nix files are used to pull in project deps, so we always need this
+    ripgrep
     screen
     tree
   ];


### PR DESCRIPTION
For *really* big projects helm just doesn't cut it, while ripgrep is a
bit faster and more ergonomic.