### PR TITLE
gcs: Switch to adoptopenjdk instead of jdk

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,6 +31,8 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - run: |
+          nix build .#gcs
+
           nix flake check \
               --no-write-lock-file \
               --override-input dotfiles "$(pwd)" \

--- a/nixpkgs/pkgs/gcs.nix
+++ b/nixpkgs/pkgs/gcs.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, jdk15, jre, makeWrapper, wrapGAppsHook }:
+{ stdenv, fetchFromGitHub, adoptopenjdk-hotspot-bin-15, jre, makeWrapper
+, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "gcs";
@@ -11,7 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "azdjFuTm7yFbG3+Iwlkm9kCYZETwZAAfD2gp7A0avHc=";
   };
 
-  nativeBuildInputs = [ jdk15 jre.gtk3 makeWrapper wrapGAppsHook ];
+  nativeBuildInputs =
+    [ adoptopenjdk-hotspot-bin-15 jre.gtk3 makeWrapper wrapGAppsHook ];
 
   dontConfigure = true;
   dontInstall = true;


### PR DESCRIPTION
Sadly the nixpkgs jdk15 was removed in favor of jdk16, but gcs can't
build with jdk16.