### PR TITLE
Update to NixOS 21.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,68 +22,32 @@
         ]
       },
       "locked": {
-        "lastModified": 1617824794,
-        "narHash": "sha256-UGkvzx0nIXHhNq/KwJLjXvKAQRE2V33MuX+UirvqrkQ=",
+        "lastModified": 1622312560,
+        "narHash": "sha256-xBWgiwnPaL/iZasPxw3BuvPAee/2jiToiZjKvKLs+PA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2aa20ae969f2597c4df10a094440a66e9d7f8c86",
+        "rev": "ab64dc32493996c24607eab2cae6663466ddfb8a",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-20.09",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "home-manager-unstable": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs-unstable"
-        ]
-      },
-      "locked": {
-        "lastModified": 1621649712,
-        "narHash": "sha256-SGOWonfYzV/Cdjfv3dlEgbMlg5yRZohTG/Cm0xcuiEA=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "4f70f49cec34cb22b9be9f42cd0dd68ef816a797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
+        "ref": "release-21.05",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1621511390,
-        "narHash": "sha256-isDpLGr73ejAiksS1eW0dOMjEIB+j8b1lyAN++5KmrA=",
+        "lastModified": 1622577619,
+        "narHash": "sha256-ODWgeRVXJz++vvapHSNO2G7AACfRjQoWMomuLhl+OcQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a7064e23973b0f3e1dd56cf4601758fedc38423c",
+        "rev": "5237039cc1e7633a7697ed7999afd1f80d91ff14",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-20.09",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1621552131,
-        "narHash": "sha256-AD/AEXv+QOYAg0PIqMYv2nbGOGTIwfOGKtz3rE+y+Tc=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d42cd445dde587e9a993cd9434cb43da07c4c5de",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-21.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -107,9 +71,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "home-manager": "home-manager",
-        "home-manager-unstable": "home-manager-unstable",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "nurpkgs": "nurpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,15 +2,10 @@
   description = "tlater's home configuration";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-20.09";
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-21.05";
     home-manager = {
-      url = "github:nix-community/home-manager/release-20.09";
+      url = "github:nix-community/home-manager/release-21.05";
       inputs.nixpkgs.follows = "nixpkgs";
-    };
-    home-manager-unstable = {
-      url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
     nurpkgs = {
       url = "github:nix-community/NUR";
@@ -19,13 +14,9 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { nixpkgs, nixpkgs-unstable, home-manager, home-manager-unstable
-    , nurpkgs, flake-utils, ... }:
+  outputs = { nixpkgs, home-manager, nurpkgs, flake-utils, ... }:
     let
       overlays = [
-        (final: prev: {
-          unstable = import nixpkgs-unstable { system = prev.system; };
-        })
         (final: prev: { local = import ./nixpkgs/pkgs { pkgs = prev; }; })
         nurpkgs.overlay
       ];
@@ -54,9 +45,7 @@
         #
         homeConfigurationFromProfile = profile:
           { system, username ? "tlater", homeDirectory ? "/home/${username}" }:
-          # The homeManagerConfiguration function is only available on
-          # unstable currently.
-          home-manager-unstable.lib.homeManagerConfiguration {
+          home-manager.lib.homeManagerConfiguration {
             inherit homeDirectory system username;
             configuration = nixosModuleFromProfile profile;
           };
@@ -91,7 +80,7 @@
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [
             nixfmt
-            home-manager-unstable.defaultPackage.${system}
+            home-manager.defaultPackage.${system}
           ];
         };
       }));

--- a/nixpkgs/configurations/graphical-programs/games.nix
+++ b/nixpkgs/configurations/graphical-programs/games.nix
@@ -1,5 +1,5 @@
 { pkgs, ... }:
 
 {
-  home.packages = with pkgs; [ unstable.multimc jre8 ];
+  home.packages = with pkgs; [ multimc jre8 ];
 }

--- a/nixpkgs/pkgs/default.nix
+++ b/nixpkgs/pkgs/default.nix
@@ -6,10 +6,9 @@ with pkgs;
   background = pkgs.callPackage ./background.nix { };
   cap = pkgs.callPackage ./cap.nix { };
   dump-ics = pkgs.callPackage ./dump-ics.nix { };
-  # FIXME: When 21.5 is stable, switch back to stable pkgs
-  emacs = pkgs.unstable.callPackage ./emacs.nix { };
+  emacs = pkgs.callPackage ./emacs.nix { };
   gauth = pkgs.callPackage ./gauth.nix { };
-  gcs = pkgs.unstable.callPackage ./gcs.nix { };
+  gcs = pkgs.callPackage ./gcs.nix { };
   oh-my-zsh-emacs = pkgs.callPackage ./oh-my-zsh-emacs.nix { };
   oh-my-zsh-require-tool = pkgs.callPackage ./oh-my-zsh-require-tool.nix { };
   oh-my-zsh-screen = pkgs.callPackage ./oh-my-zsh-screen.nix { };


### PR DESCRIPTION
This updates everything to the 21.05 release, getting rid of any
references to unstable packages in the process.