### PR TITLE
Fix some work-laptop specific fallout from the upgrade

### DIFF
--- a/nixpkgs/configurations/tty-programs/mail/work.nix
+++ b/nixpkgs/configurations/tty-programs/mail/work.nix
@@ -11,7 +11,7 @@
 
       userName = "tristanmaat";
       passwordCommand =
-        "PASSWORD_STORE_DIR=${config.xdg.dataHome}/password-store ${pkgs.pass}/bin/pass work/codethink.co.uk | head -n 1 | ${pkgs.coreutils}/bin/tr -d '\\n'";
+        "PASSWORD_STORE_DIR=${config.xdg.dataHome}/password-store ${pkgs.pass}/bin/pass work/codethink.co.uk | ${pkgs.coreutils}/bin/head -n 1 | ${pkgs.coreutils}/bin/tr -d '\\n'";
       imap = {
         host = "mail.codethink.co.uk";
         port = 993;

--- a/nixpkgs/configurations/tty-programs/work.nix
+++ b/nixpkgs/configurations/tty-programs/work.nix
@@ -3,4 +3,5 @@
 {
   home.packages = with pkgs; [ local.gauth ];
   programs.git.userEmail = lib.mkOverride 99 "tristan.maat@codethink.co.uk";
+  programs.gpg.scdaemonSettings.reader-port = "Yubico Yubi";
 }


### PR DESCRIPTION
- `pass show` broke API
- home-manager now configures the scdaemon, which needs additional
  configuration for yubikeys on this laptop