### PR TITLE
home-manager: Switch back to 21.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,15 +22,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1624214437,
-        "narHash": "sha256-BtB6k1mQXG/P8MUlNVcuboQqlxlks2H6i5vj2pbGa3Y=",
+        "lastModified": 1624228557,
+        "narHash": "sha256-wwOqe73BsrXfRv1PhyXQFNC8iTET50KvE/HitdkRgxs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cd11c02c286a996ff55010146baecae4c413634f",
+        "rev": "35a24648d155843a4d162de98c17b1afd5db51e4",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "release-21.05",
         "repo": "home-manager",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-21.05";
     home-manager = {
-      url = "github:nix-community/home-manager";
+      url = "github:nix-community/home-manager/release-21.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     nurpkgs = {


### PR DESCRIPTION
This reverts commit 613a809a66bd37ce8e75c0e1094ea674686e0197.

See TLATER/nixos-hosts#55.

Flake input changes:

* Updated 'home-manager': 'github:nix-community/home-manager/148d85ee8303444fb0116943787aa0b1b25f94df' -> 'github:nix-community/home-manager/35a24648d155843a4d162de98c17b1afd5db51e4'