### PR TITLE
gcs: Make package work with the newest gcs version

### DIFF
--- a/nixpkgs/pkgs/gcs.nix
+++ b/nixpkgs/pkgs/gcs.nix
@@ -1,5 +1,5 @@
-{ sources, stdenv, adoptopenjdk-hotspot-bin-15, jre, makeWrapper, wrapGAppsHook
-}:
+{ sources, lib, stdenv, adoptopenjdk-hotspot-bin-15, jre, makeWrapper
+, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   inherit (sources.gcs) pname version src;
@@ -11,19 +11,20 @@ stdenv.mkDerivation rec {
   dontInstall = true;
 
   buildPhase = ''
-    mkdir -p out/bootstrap
-    javac -d out/bootstrap -encoding UTF8 ./bundler/bundler/Bundler.java
-    java -cp out/bootstrap bundler.Bundler --unpackaged
+    patchShebangs bundle.sh
+    substituteInPlace bundle.sh --replace /bin/rm rm
+    ./bundle.sh --unpackaged
   '';
 
-  preFixup = ''
+  preFixup = let v = lib.removePrefix "v" version;
+  in ''
     mkdir -p $out/{bin,share}
     cp -r out/dist/modules $out/share/java
 
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
     makeWrapper ${jre}/bin/java $out/bin/gcs \
         ''${makeWrapperArgs[@]} \
-          --add-flags "-cp $out/share/java/com.lowagie.text-2.1.7.jar:$out/share/java/com.trollworks.gcs-${version}.jar com.trollworks.gcs.GCS"
+          --add-flags "-cp $out/share/java/com.lowagie.text-2.1.7.jar -jar $out/share/java/com.trollworks.gcs-${v}.jar"
   '';
 
   dontWrapGApps = true;


### PR DESCRIPTION
- Use the new `bundle.sh` script instead of manually calling the
  bundler
  - Sadly it uses `/bin/bash` and `/bin/rm`, but I don't think
    upstream would/should care so we just patch it
- Get rid of the "v" prefix in the version number for the jarfile
  - Yes, I don't know why this changed either, and yes, it took me 20
    minutes to figure that out
- Call the jarfile directly, instead of putting it on the classpath
  - Just in case the main class does change as was assumed during
    debugging of the previous point