### PR TITLE
firefox: Remove add-on related anti-features

### DIFF
--- a/nixpkgs/configurations/graphical-programs/firefox.nix
+++ b/nixpkgs/configurations/graphical-programs/firefox.nix
@@ -41,6 +41,7 @@
 
         # Actual settings
         "app.shield.optoutstudies.enabled" = false;
+        "app.update.auto" = false;
         "browser.bookmarks.restore_default_bookmarks" = false;
         "browser.contentblocking.category" = "strict";
         "browser.ctrlTab.recentlyUsedOrder" = false;
@@ -51,14 +52,14 @@
         "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features" =
           false;
         "browser.newtabpage.activity-stream.feeds.snippets" = false;
-        "browser.newtabpage.activity-stream.showSponsored" = false;
-        "browser.newtabpage.activity-stream.showSponsoredTopSites" = false;
         "browser.newtabpage.activity-stream.improvesearch.topSiteSearchShortcuts.havePinned" =
           "";
         "browser.newtabpage.activity-stream.improvesearch.topSiteSearchShortcuts.searchEngines" =
           "";
         "browser.newtabpage.activity-stream.section.highlights.includePocket" =
           false;
+        "browser.newtabpage.activity-stream.showSponsored" = false;
+        "browser.newtabpage.activity-stream.showSponsoredTopSites" = false;
         "browser.newtabpage.pinned" = false;
         "browser.protections_panel.infoMessage.seen" = true;
         "browser.quitShortcut.disabled" = true;
@@ -67,9 +68,12 @@
         "browser.toolbars.bookmarks.visibility" = "never";
         "browser.urlbar.placeholderName" = "DuckDuckGo";
         "browser.urlbar.suggest.openpage" = false;
+        "datareporting.policy.dataSubmissionEnable" = false;
         "datareporting.policy.dataSubmissionPolicyAcceptedVersion" = 2;
         "dom.security.https_only_mode" = true;
         "dom.security.https_only_mode_ever_enabled" = true;
+        "extensions.getAddons.showPane" = false;
+        "extensions.htmlaboutaddons.recommendations.enabled" = false;
         "extensions.pocket.enabled" = false;
         "identity.fxaccounts.enabled" = false;
         "privacy.trackingprotection.enabled" = true;


### PR DESCRIPTION
They auto-update, but I want to do this with nix, and apparently
mozilla collects info about which you have to recommend you new ones.