### PR TITLE
commit-nvfetcher: Don't create no-op commits

### DIFF
--- a/dotfiles/bin/commit-nvfetcher
+++ b/dotfiles/bin/commit-nvfetcher
@@ -10,8 +10,17 @@ cat <<EOF > "${TMPDIR}/commit-summary"
 sources.nix: Update
 
 EOF
-cat "${TMPDIR}/commit-summary" "${TMPDIR}/changelog" > "${TMPDIR}/commit-message"
 
-git commit _sources/ -F "${TMPDIR}/commit-message"
+if [ -s "${TMPDIR}/changelog" ]; then
+    cat "${TMPDIR}/commit-summary" "${TMPDIR}/changelog" > "${TMPDIR}/commit-message"
+    git commit _sources/ -F "${TMPDIR}/commit-message"
+else
+    # Clean up any debris nvfetcher may leave in its database.
+    #
+    # This should be "safe", since nvfetcher will override whatever
+    # the user had previously anyway, so at least it won't break
+    # anything further than running nvfetcher already did.
+    git restore _sources/
+fi
 
 rm -rf "${TMPDIR}"

--- a/dotfiles/bin/commit-nvfetcher
+++ b/dotfiles/bin/commit-nvfetcher
@@ -23,4 +23,4 @@ else
     git restore _sources/
 fi
 
-rm -rf "${TMPDIR}"
+rm -r "${TMPDIR}"


### PR DESCRIPTION
As it turns out, nvfetcher will update its database even if there are
no updates.

Obviously we don't want to create commits (and worse, PRs) in that
case, so we check if the changelog contains any updates before
committing.

We also clean up after ourselves if this happens, in case the script
is run manually.