### PR TITLE
emacs: Fix recentf save behavior

### DIFF
--- a/dotfiles/emacs.d/config/misc.el
+++ b/dotfiles/emacs.d/config/misc.el
@@ -59,7 +59,9 @@
 (use-package recentf
   :ensure nil
   :init
-  (setq recentf-save-file (expand-file-name "recentf" data-dir)))
+  (setq recentf-save-file (expand-file-name "recentf" data-dir))
+  :config
+  (add-hook 'delete-frame-functions (lambda (terminal) (recentf-save-list))))
 
 (use-package tramp
   :ensure nil


### PR DESCRIPTION
By default, recentf will only save the recentf file if emacs is quit
properly.

However, because I am running emacs in daemon mode via systemd, it
appears to not be shut down gracefully. Instead, we save the recentf
list every time a frame is closed.

I do so habitually before shutting down my system anyway, so this
should resolve the problem.