### PR TITLE
emacs: Improve file formatting

### DIFF
--- a/dotfiles/emacs.d/config/file-types.el
+++ b/dotfiles/emacs.d/config/file-types.el
@@ -90,9 +90,7 @@
   :mode (rx ".csv" string-end))
 
 (use-package nix-mode
-  :mode (rx ".nix" string-end)
-  :bind (:map nix-mode-map
-              ("C-c f" . nix-format-buffer)))
+  :mode (rx ".nix" string-end))
 
 (use-package stumpwm-mode
   :mode (rx "stumpwm/" (* anychar) string-end))
@@ -108,8 +106,6 @@
 
 (use-package web-mode
   :bind
-  (:map web-mode-map
-        ("C-c f" . prettier-js))
   :mode (rx (or ".pug" ".hbs" (and ".ts" (? "x"))) string-end))
 
 (use-package prettier-js

--- a/dotfiles/emacs.d/config/keybindings.el
+++ b/dotfiles/emacs.d/config/keybindings.el
@@ -35,6 +35,21 @@
   (interactive)
   (other-window -1))
 
+(defun autoformat ()
+  "Autoformat the current buffer."
+  (interactive)
+  (pcase major-mode
+    ('python-mode (progn
+                     (py-isort-buffer)
+                     (blacken-buffer)))
+    ('nix-mode (nix-format-buffer))
+    ('web-mode (prettier-js))
+    (_ (if (bound-and-true-p lsp-mode)
+           (lsp-format-buffer)
+         (message "No formatter for this file type")))))
+
+(global-set-key (kbd "C-c f") 'autoformat)
+
 (global-set-key (kbd "M-p") 'backward-paragraph)
 (global-set-key (kbd "M-n") 'forward-paragraph)
 

--- a/dotfiles/emacs.d/config/lsp.el
+++ b/dotfiles/emacs.d/config/lsp.el
@@ -29,7 +29,6 @@
   :hook ((web-mode rust-mode python-mode sh-mode c-mode c++-mode) . lsp)
   :bind
   (:map lsp-mode-map
-   ("C-c f" . lsp-format-buffer)
    ("C-c l r" . lsp-rename)
    ("C-c l d" . lsp-describe-thing-at-point))
   :init
@@ -77,6 +76,8 @@
 (use-package lsp-ui
   :hook (lsp-mode . lsp-ui-mode)
   :after (lsp-mode))
+
+(use-package lsp-pyright)
 
 (provide 'lsp)
 ;;; lsp.el ends here

--- a/dotfiles/emacs.d/config/python.el
+++ b/dotfiles/emacs.d/config/python.el
@@ -46,5 +46,11 @@
               ("C-c t a" . pytest-all)
               ("C-c t m" . pytest-module)))
 
+(use-package py-isort
+  :commands (py-isort-buffer))
+
+(use-package blacken
+  :commands (blacken-buffer))
+
 (provide 'python)
 ;;; python.el ends here


### PR DESCRIPTION
This is mainly motivated by pyls no longer existing, and
auto-formatting therefore being quite difficult for python.