### PR TITLE
ssh: Use `VerifyHostKeyDNS` for work ssh servers that support it

### DIFF
--- a/nixpkgs/configurations/tty-programs/work.nix
+++ b/nixpkgs/configurations/tty-programs/work.nix
@@ -4,4 +4,21 @@
   home.packages = with pkgs; [ local.gauth ];
   programs.git.userEmail = lib.mkOverride 99 "tristan.maat@codethink.co.uk";
   programs.gpg.scdaemonSettings.reader-port = "Yubico Yubi";
+
+  programs.ssh = {
+    matchBlocks = {
+      "shell.codethink.co.uk" = lib.hm.dag.entryAfter [ "*" ] {
+        user = "tristanmaat";
+        extraOptions = { "VerifyHostKeyDNS" = "yes"; };
+      };
+      "gitlab.codethink.co.uk" = lib.hm.dag.entryAfter [ "*" ] {
+        user = "git";
+        extraOptions = { "VerifyHostKeyDNS" = "yes"; };
+      };
+      "git.codethink.co.uk" = lib.hm.dag.entryAfter [ "*" ] {
+        user = "git";
+        extraOptions = { "VerifyHostKeyDNS" = "yes"; };
+      };
+    };
+  };
 }


### PR DESCRIPTION
This may be rolled out to other services in the future, keep an eye on
it.