### PR TITLE
Emacs: Configure eglot for use with python-lsp-server

### DIFF
--- a/dotfiles/emacs.d/config/eglot.el
+++ b/dotfiles/emacs.d/config/eglot.el
@@ -30,6 +30,29 @@
   :bind
   (:map eglot-mode-map
         ("C-c l r" . eglot-rename))
+  :init
+  (setq eglot-workspace-configuration
+        '((pylsp
+           (plugins
+            (pydocstyle
+             (enabled . t)
+             ;; Does not currently work:
+             ;; https://github.com/python-lsp/python-lsp-server/issues/159
+             (match . ".*"))
+            (pycodestyle
+             ;; Make compatible with black:
+             ;; https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length
+             (maxLineLength . 88)
+             ;; Only E203 is incompatible with black and enabled by
+             ;; default, but defining *any* ignore list will override
+             ;; the default ignore list, so we need to recreate the
+             ;; original.
+             ;;
+             ;; See also the small caveat under the huge table here:
+             ;; https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
+             (ignore . ["E203" "E121" "E123" "E126" "E133" "E226"
+                        "E241" "E242" "E704" "W503" "W504" "W505"]))))))
+
   :config
   (add-to-list 'eglot-server-programs '(web-mode . ("typescript-language-server" "--stdio"))))
 

--- a/dotfiles/emacs.d/config/file-types.el
+++ b/dotfiles/emacs.d/config/file-types.el
@@ -67,8 +67,7 @@
   :mode ((rx ".rs" string-end) . rustic-mode)
   :config
   (require 'smartparens-rust)
-  (setq rustic-lsp-client 'eglot)
-  (remove-hook 'rustic-mode-hook 'flycheck-mode))
+  (setq rustic-lsp-client 'eglot))
 
 (use-package cython-mode
   :mode (rx ".pyx" string-end))

--- a/dotfiles/emacs.d/config/keybindings.el
+++ b/dotfiles/emacs.d/config/keybindings.el
@@ -35,20 +35,6 @@
   (interactive)
   (other-window -1))
 
-(defun show-buffer-errors ()
-  "Show errors from flymake or flycheck.
-
-   This shows errors depending on which checker is responsible
-   for a given mode."
-  (interactive)
-  (pcase major-mode
-    ('rustic-mode (flymake-show-diagnostics-buffer))
-    (_ (if (bound-and-true-p eglot--managed-mode)
-           (flymake-show-diagnostics-buffer)
-         ;; If eglot-mode isn't enabled, assume flycheck because I'm
-         ;; probably using its backend
-         (flycheck-list-errors)))))
-
 (defun autoformat ()
   "Autoformat the current buffer."
   (interactive)
@@ -65,7 +51,7 @@
          (message "No formatter for this file type")))))
 
 (global-set-key (kbd "C-c l d") 'eldoc-doc-buffer)
-(global-set-key (kbd "C-c l e") 'show-buffer-errors)
+(global-set-key (kbd "C-c l e") 'flymake-show-buffer-diagnostics)
 (global-set-key (kbd "C-c l f") 'xref-find-definitions-other-window)
 
 (global-set-key (kbd "C-c f") 'autoformat)

--- a/dotfiles/emacs.d/config/keybindings.el
+++ b/dotfiles/emacs.d/config/keybindings.el
@@ -39,9 +39,6 @@
   "Autoformat the current buffer."
   (interactive)
   (pcase major-mode
-    ('python-mode (progn
-                     (py-isort-buffer)
-                     (blacken-buffer)))
     ('nix-mode (nix-format-buffer))
     ('web-mode (prettier-js))
     ('rustic-mode (rustic-format-buffer))

--- a/dotfiles/emacs.d/config/packages.el
+++ b/dotfiles/emacs.d/config/packages.el
@@ -89,12 +89,6 @@
   :init
   (setq company-idle-delay 0.1))
 
-;; In-line linting
-(use-package flycheck
-  :functions (global-flycheck-mode)
-  :config
-  (global-flycheck-mode))
-
 (use-package flyspell
   :ensure nil
   :bind (:map flyspell-mode-map
@@ -284,6 +278,14 @@
   :ensure nil
   :init
   (setq eshell-directory-name (expand-file-name "eshell" data-dir)))
+
+(use-package flymake
+  :ensure nil
+  :hook (prog-mode . flymake-mode))
+
+(use-package flymake-shellcheck
+  :commands flymake-shellcheck-load
+  :hook (sh-mode . flymake-shellcheck-load))
 
 (provide 'packages)
 ;;; packages.el ends here

--- a/dotfiles/emacs.d/config/python.el
+++ b/dotfiles/emacs.d/config/python.el
@@ -46,11 +46,5 @@
               ("C-c t a" . pytest-all)
               ("C-c t m" . pytest-module)))
 
-(use-package py-isort
-  :commands (py-isort-buffer))
-
-(use-package blacken
-  :commands (blacken-buffer))
-
 (provide 'python)
 ;;; python.el ends here

--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,6 @@
                 mccabe
                 pycodestyle
                 pydocstyle
-                yapf
               ]))
           ];
         };


### PR DESCRIPTION
This isn't entirely functional yet, see:
https://github.com/python-lsp/python-lsp-server/issues/159