### PR TITLE
emacs: Add nix templates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,8 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - run: |
-          find . -type f -name '*.nix' \
+          find . -path ./dotfiles/emacs.d/share/yatemplate -prune \
+                 -type f -name '*.nix' \
                  ! -name 'hardware-configuration.nix' \
                  ! -name 'generated.nix' \
                  -exec nix run nixpkgs#nixfmt -- -c {} +

--- a/dotfiles/emacs.d/share/yatemplate/03:shell.nix
+++ b/dotfiles/emacs.d/share/yatemplate/03:shell.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs;
+    [
+      $0
+    ];
+  shellHook = ''
+
+  '';
+}

--- a/dotfiles/emacs.d/share/yatemplate/04:flake.nix
+++ b/dotfiles/emacs.d/share/yatemplate/04:flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "$1";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-$2";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, flake-utils, ... }:
+    let inherit (flake-utils.lib) eachSystem defaultSystems;
+    in {
+
+    } // (eachSystem defaultSystems) (system:
+      let pkgs = import nixpkgs { inherit system; };
+      in {
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs;
+            [
+              $0
+            ];
+          shellHook = ''
+
+          '';
+        };
+      });
+}


### PR DESCRIPTION
Add templates for `shell.nix` and `flake.nix` files.

This should probably be extended to have a flake with nice, pre-made
`devShells` for a variety of environments, but this helps setting up
one-off project directories for now.