### PR TITLE
emacs: Improve Bazel workflow

### DIFF
--- a/dotfiles/emacs.d/config/keybindings.el
+++ b/dotfiles/emacs.d/config/keybindings.el
@@ -43,6 +43,9 @@
     ('web-mode (prettier-js))
     ('rustic-mode (rustic-format-buffer))
     ('haskell-mode (haskell-mode-stylish-buffer))
+    ((or 'bazel-mode
+         (app (lambda (m) (get m 'derived-mode-parent)) 'bazel-mode))
+     (bazel-buildifier))
     (_ (if (eglot-managed-p)
            (eglot-format)
          (message "No formatter for this file type")))))

--- a/nixpkgs/configurations/tty-programs/emacs.nix
+++ b/nixpkgs/configurations/tty-programs/emacs.nix
@@ -3,9 +3,7 @@
 {
   home.packages = with pkgs; [
     # Spell checks
-    aspell
-    aspellDicts.en
-    aspellDicts.en-computers
+    (aspellWithDicts (dicts: with dicts; [ af de en en-computers nl ]))
 
     # Used for interactive python shells
     python3Packages.ipython


### PR DESCRIPTION
Adds a buildifier formatter and fixes spell checking on non-NixOS
systems (need to run Bazel in a VM pretty frequently, so spell
checking needs to work there).