### PR TITLE
Fix a variety of env var settings

### DIFF
--- a/dotfiles/emacs.d/config/eglot.el
+++ b/dotfiles/emacs.d/config/eglot.el
@@ -63,7 +63,7 @@
     (pcase (eglot--major-mode server)
       ('rust-mode '(:checkOnSave
                     (:command "clippy")))
-      (_ (eglot--{}))))
+      (_ eglot--{})))
 
   (add-to-list 'eglot-server-programs '(web-mode . ("typescript-language-server" "--stdio"))))
 

--- a/dotfiles/env
+++ b/dotfiles/env
@@ -1,5 +1,19 @@
+#shellcheck shell=sh disable=SC1091 disable=SC1090
+
 # Set up home-manager
-[ -f "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh" ] && source "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
+if [ -f "/etc/profiles/per-user/${USER}/etc/profile.d/hm-session-vars.sh" ]; then
+    # On NixOS with flakes, it seems the user profile is in
+    # /etc/profiles/per-user/
+    . "/etc/profiles/per-user/${USER}/etc/profile.d/hm-session-vars.sh"
+elif [ -f "${NIX_USER_PROFILE_DIR}/profile/etc/profile.d/hm-session-vars.sh" ]; then
+    # On non-NixOS, this might be the correct path? The path is almost
+    # entirely empty on NixOS.
+    . "${NIX_USER_PROFILE_DIR}/profile/etc/profile.d/hm-session-vars.sh"
+elif [ -f "${HOME}/.nix-profile/etc/profile.d/hm-session-vars.sh" ]; then
+    # This is a fallback for non-NixOS, where the previous variable
+    # may not always be set.
+    . "${HOME}/.nix-profile/etc/profile.d/hm-session-vars.sh"
+fi
 
 # Set emacsclient as a "browser" - xdg-open naively checks this
 # variable to open unknown file types, or otherwise tries to open

--- a/dotfiles/zsh/.zshrc
+++ b/dotfiles/zsh/.zshrc
@@ -1,5 +1,7 @@
+#shellcheck shell=bash disable=SC1091 disable=SC1090
+
 # Load environment configuration first
-[ -f "$HOME/.config/dir_colors" ] && eval `dircolors "$HOME/.config/dir_colors"`
+[ -f "$HOME/.config/dir_colors" ] && eval "$(dircolors "$HOME/.config/dir_colors")"
 [ -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ] && source "$HOME/.nix-profile/etc/profile.d/nix.sh"
 [ -f "$HOME/.nix-profile/etc/profile.d/nix-daemon.sh" ] && source "$HOME/.nix-profile/etc/profile.d/nix-daemon.sh"
 export "NIX_PATH=${NIX_PATH:-$HOME/.nix-defexpr/channels${NIX_PATH:+:}$NIX_PATH}"
@@ -37,13 +39,13 @@ if [[ -o interactive ]]; then
 
     # Start screen if...
     if \
-        # The command exists \
+        # The command exists
         (( $+commands[screen] )) && \
-            # The configuration file exists \
+            # The configuration file exists
             [ -f "$XDG_CONFIG_HOME/screen/config" ] && \
-            # Screen is not already running \
+            # Screen is not already running
             [ -z "$STY" ] && \
-            # And our terminal is acceptable \
+            # And our terminal is acceptable
             [ "$TERM" != "dumb" ] && \
             [ "$TERM" != "linux" ]; then
         exec screen -AxRR -c "$XDG_CONFIG_HOME/screen/config"

--- a/dotfiles/zsh/.zshrc
+++ b/dotfiles/zsh/.zshrc
@@ -1,7 +1,5 @@
 # Load environment configuration first
 [ -f "$HOME/.config/dir_colors" ] && eval `dircolors "$HOME/.config/dir_colors"`
-[ -f "$HOME/.profile" ] && source "$HOME/.profile"
-[ -f "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh" ] && source "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
 [ -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ] && source "$HOME/.nix-profile/etc/profile.d/nix.sh"
 [ -f "$HOME/.nix-profile/etc/profile.d/nix-daemon.sh" ] && source "$HOME/.nix-profile/etc/profile.d/nix-daemon.sh"
 export "NIX_PATH=${NIX_PATH:-$HOME/.nix-defexpr/channels${NIX_PATH:+:}$NIX_PATH}"

--- a/dotfiles/zshenv
+++ b/dotfiles/zshenv
@@ -1,3 +1,4 @@
 setopt no_global_rcs
+[ -f "$HOME/.profile" ] && source "$HOME/.profile"
 HISTFILE="$XDG_DATA_HOME/.zsh_history"
 ZDOTDIR="$XDG_CONFIG_HOME/zsh"

--- a/nixpkgs/configurations/history.py
+++ b/nixpkgs/configurations/history.py
@@ -1,0 +1,34 @@
+"""Fix python's history file mess."""
+
+import sys
+
+
+def register_readline():
+    """Readline configuration function.
+
+    Overriding https://github.com/python/cpython/blob/v3.7.0b5/Lib/site.py#L405
+    """
+    import atexit
+    import os
+
+    try:
+        import readline
+        from pathlib import Path
+    except ImportError:
+        return
+
+    cache_home = (
+        Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")) / "python"
+    ).expanduser()
+    cache_home.mkdir(parents=True, exist_ok=True)
+    history = str(cache_home / "history")
+
+    try:
+        readline.read_history_file(history)
+    except OSError:
+        pass
+
+    atexit.register(readline.write_history_file, history)
+
+
+sys.__interactivehook__ = register_readline

--- a/nixpkgs/configurations/xdg-settings.nix
+++ b/nixpkgs/configurations/xdg-settings.nix
@@ -36,7 +36,6 @@ in {
     XCOMPOSECACHE = "${xdg.cacheHome}/X11/xcompose";
     XCOMPOSEFILE = "${xdg.configHome}/X11/xcompose";
     MAILCAPS = "${xdg.configHome}/mailcap";
-    PYTHONSTARTUP = "${xdg.configHome}/python/startup.py";
     IPYTHONDIR = "${xdg.dataHome}/ipython";
     JUPYTER_CONFIG_DIR = "${xdg.dataHome}/ipython";
     HISTFILE = "${xdg.dataHome}/histfile";
@@ -60,13 +59,7 @@ in {
       tmp=$XDG_RUNTIME_DIR/npm
       init-module=${xdg.configHome}/npm/config/npm-init.js
     '';
-  };
 
-  # Aaand python is configured using a python script. Wonderful.
-  xdg.configFile."python/startup.py" = {
-    text = ''
-      import readline
-      readline.set_auto_history(False)
-    '';
+    PYTHONSTARTUP = ./history.py;
   };
 }

--- a/nixpkgs/configurations/xdg-settings.nix
+++ b/nixpkgs/configurations/xdg-settings.nix
@@ -1,8 +1,10 @@
 {
+  pkgs,
   config,
   lib,
   ...
 }: let
+  inherit (pkgs) writeText;
   xdg = config.xdg;
 in {
   home.activation = {
@@ -32,14 +34,14 @@ in {
     CARGO_HOME = "${xdg.cacheHome}/cargo";
     RUSTUP_HOME = "${xdg.dataHome}/rustup";
     XCOMPOSECACHE = "${xdg.cacheHome}/X11/xcompose";
-    XCOMPOSEFILE = "${xdg.configHome}X11/xcompose";
-    NPM_CONFIG_USERCONFIG = "${xdg.configHome}/npm/npmrc";
+    XCOMPOSEFILE = "${xdg.configHome}/X11/xcompose";
     MAILCAPS = "${xdg.configHome}/mailcap";
     PYTHONSTARTUP = "${xdg.configHome}/python/startup.py";
     IPYTHONDIR = "${xdg.dataHome}/ipython";
     JUPYTER_CONFIG_DIR = "${xdg.dataHome}/ipython";
     HISTFILE = "${xdg.dataHome}/histfile";
     RLWRAP_HOME = "${xdg.dataHome}/rlwrap"; # stumpish and perhaps others
+    CUDA_CACHE_PATH = "${xdg.dataHome}/cuda";
 
     # See, this is exactly why things should follow the spec. I have
     # no intention of using gradle ever, but occasionally I need to
@@ -51,15 +53,14 @@ in {
     #
     # Grmbl.
     GRADLE_USER_HOME = "${xdg.cacheHome}/gradle";
-  };
 
-  # More hacks to avoid stupid package managers puking all over my
-  # $HOME, for this one I even need a permanent file in ~/.config!
-  xdg.configFile."npm/npmrc".text = ''
-    prefix=${xdg.cacheHome}/npm
-    cache=${xdg.cacheHome}/npm
-    tmp=$XDG_RUNTIME_DIR/npm
-  '';
+    NPM_CONFIG_USERCONFIG = writeText "npmrc" ''
+      prefix=${xdg.cacheHome}/npm
+      cache=${xdg.cacheHome}/npm
+      tmp=$XDG_RUNTIME_DIR/npm
+      init-module=${xdg.configHome}/npm/config/npm-init.js
+    '';
+  };
 
   # Aaand python is configured using a python script. Wonderful.
   xdg.configFile."python/startup.py" = {


### PR DESCRIPTION
This fixes:

- `~/.profile` not correctly sourcing the home-manager vars
  - This caused basically all XDG basedir overrides to not work under
    certain circumstances
- A few bugs in the XDG basedir overrides
  - Added CUDA_FILE_PATH
  - Fixed XCOMPOSEFILE
  - Refactored the npm config
  - Made the python config actually work
- Shellchecking zshrc/zshenv, and ensuring `~/.profile` is included in
  the zshrc already

A fix for a typo in the eglot config for emacs snuck in too.