### PR TITLE
work.nix: Fix yubikey detection

### DIFF
--- a/nixpkgs/configurations/tty-programs/work.nix
+++ b/nixpkgs/configurations/tty-programs/work.nix
@@ -5,7 +5,6 @@
 }: {
   home.packages = with pkgs; [local.gauth];
   programs.git.userEmail = lib.mkOverride 99 "tristan.maat@codethink.co.uk";
-  programs.gpg.scdaemonSettings.reader-port = "Yubico Yubi";
 
   programs.ssh = {
     matchBlocks = {


### PR DESCRIPTION
Seems the scdaemon can now detect the yubikey without specifying it explicitly, and in fact fails when we do specify it.