### PR TITLE
flake.nix: Add back homeConfigurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ My NixOS-managed dotfiles repository.
 
 ## Installation
 
+### NixOS configurations
+
+This flake contains two NixOS configurations, `yui` and
+`ct-lt-02052`. Both come with the home-manager-managed dotfiles
+pre-installed.
+
 ### Non-NixOS
 
 For non-NixOS hosts, this requires nix >=2.4 with flakes enabled. To
@@ -22,48 +28,5 @@ home-manager:
 
 ```bash
 nix develop github:tlater/dotfiles
-home-manager switch --flake github:tlater/dotfiles#tlater
-```
-
-#### Flake Targets
-
-Possible targets are:
-
-- `github:tlater/dotfiles#tlater`
-  - A minimal configuration that is intended for text-only interfaces,
-    what you'd want on a headless server.
-- `github:tlater/dotfiles#graphical`
-  - A slightly bigger set of options for things like graphical VMs.
-
-### NixOS
-
-This requires using the home-manager flake module. This flake provides
-a utility function to make this as easy as possible
-(`lib.nixosConfigurationFromProfile`), which will create a module from
-a profile and username that can simply be passed to
-`nixpkgs.lib.nixosSystem`.
-
-Minimal example for a personal PC with the user tlater:
-
-```nix
-{
-  inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-20.09";
-    home-manager.url = "github:nix-community/home-manager/release-20.09";
-    dotfiles.url = "github:tlater/dotfiles";
-  };
-
-  outputs = { nixpkgs, home-manager, dotfiles, ... }: {
-    nixosConfigurations = {
-      example = nixpkgs.lib.nixosSystem {
-        system = "x86_64-linux";
-        modules = [
-          home-manager.nixosModules.home-manager
-          (dotfiles.lib.nixosConfigurationFromProfile
-            dotfiles.profiles.pcs.personal "tlater")
-        ];
-      };
-    };
-  };
-}
+home-manager switch --flake github:tlater/dotfiles#gnome-vm
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,21 @@
       };
     };
 
+    homeConfigurations = {
+      # NixOS home configuration setup lives in
+      # nixos-config/default.nix and their respective host-specific
+      # modules.
+
+      gnome-vm = home-manager.lib.homeManagerConfiguration {
+        system = "x86_64-linux";
+        username = "tlater";
+        homeDirectory = "/home/tlater";
+
+        configuration = ./home-config/hosts/gnome-vm.nix;
+        extraSpecialArgs.flake-inputs = inputs;
+      };
+    };
+
     packages.x86_64-linux = import ./pkgs {
       inherit self;
       pkgs = nixpkgs.legacyPackages.x86_64-linux;

--- a/home-config/config/default.nix
+++ b/home-config/config/default.nix
@@ -5,6 +5,7 @@
 }: {
   imports = [
     ./options.nix
+    ./non-nixos.nix
 
     ./desktop
     ./graphical-applications

--- a/home-config/config/non-nixos.nix
+++ b/home-config/config/non-nixos.nix
@@ -1,0 +1,32 @@
+{
+  flake-inputs,
+  config,
+  lib,
+  pkgs,
+  ...
+}: {
+  config = lib.mkIf config.custom.is-nixos {
+    nix = {
+      package = pkgs.nixFlakes;
+      extraOptions = ''
+        experimental-features = nix-command flakes
+      '';
+
+      registry.nixpkgs = {
+        from = {
+          id = "nixpkgs";
+          type = "indirect";
+        };
+        flake = flake-inputs.nixpkgs;
+      };
+    };
+
+    nixpkgs.overlays = [
+      flake-inputs.nurpkgs.overlay
+    ];
+
+    home.sessionVariables = {
+      NIX_PATH = "nixpkgs=${flake-inputs.nixpkgs}";
+    };
+  };
+}

--- a/home-config/config/options.nix
+++ b/home-config/config/options.nix
@@ -13,5 +13,6 @@ in {
     has-yubikey = mkEnableOption "Set up settings that require my yubikey to work";
     is-work = mkEnableOption "Set up settings for work computers";
     software-kvm = mkEnableOption "Set up software kvm";
+    is-nixos = mkEnableOption "Whether this is a NixOS configuration";
   };
 }

--- a/home-config/hosts/gnome-vm.nix
+++ b/home-config/hosts/gnome-vm.nix
@@ -1,0 +1,17 @@
+{
+  imports = [
+    ../.
+  ];
+
+  custom = {
+    desktop-environment = false;
+    download-manager = false;
+    graphical-applications = false;
+    has-yubikey = false;
+    # Actually, it is usually work, but the configuration means something else
+    # TODO(tlater): Find a better name for this config option
+    is-work = false;
+    software-kvm = false;
+    is-nixos = false;
+  };
+}

--- a/home-config/hosts/personal-desktop.nix
+++ b/home-config/hosts/personal-desktop.nix
@@ -10,5 +10,6 @@
     has-yubikey = true;
     is-work = false;
     software-kvm = true;
+    is-nixos = true;
   };
 }

--- a/home-config/hosts/work-desktop.nix
+++ b/home-config/hosts/work-desktop.nix
@@ -11,5 +11,6 @@
     has-yubikey = true;
     is-work = true;
     software-kvm = true;
+    is-nixos = true;
   };
 }


### PR DESCRIPTION
For now, only the `gnome-vm` will be populated, since I'm not using it for anything else right this instant.