### PR TITLE
Switch to unstable linux kernel to work around bluetooth/nvidia being incompatible

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,6 +69,42 @@
         "type": "github"
       }
     },
+    "nixpkgs-unfree": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1653662045,
+        "narHash": "sha256-pTn2FPLsaHMWcP442jTN30YQZlO9K9VbWjkK6u++Q1g=",
+        "owner": "numtide",
+        "repo": "nixpkgs-unfree",
+        "rev": "d9e8ab22f97457284c676885bc874f2fa8552ea4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nixpkgs-unfree",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1669052418,
+        "narHash": "sha256-M1I4BKXBQm2gey1tScemEh5TpHHE3gKptL7BpWUvL8s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "20fc948445a6c22d4e8d5178e9a6bc6e1f5417c8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nurpkgs": {
       "locked": {
         "lastModified": 1668824454,
@@ -89,6 +125,8 @@
         "home-manager": "home-manager",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unfree": "nixpkgs-unfree",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "nurpkgs": "nurpkgs",
         "sops-nix": "sops-nix"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1668334946,
-        "narHash": "sha256-omMbUj4r5DVBWh7KxkoO/Z/1V1shVR6Ls4jXNB4mr3U=",
+        "lastModified": 1669146234,
+        "narHash": "sha256-HEby7EG1yaq1oT2Ze6Cvok9CFju1XHkSvVHmkptLW9U=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e0452b33ab0ef16ffe075e980644ed92a6a200bb",
+        "rev": "0099253ad0b5283f06ffe31cf010af3f9ad7837d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,11 @@
   inputs = {
     # NixOS related inputs
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-unfree = {
+      url = "github:numtide/nixpkgs-unfree";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
     sops-nix = {
       url = "github:Mic92/sops-nix";

--- a/nixos-config/yui/default.nix
+++ b/nixos-config/yui/default.nix
@@ -10,6 +10,7 @@ in {
     flake-inputs.nixos-hardware.nixosModules.common-pc
     flake-inputs.nixos-hardware.nixosModules.common-pc-ssd
     flake-inputs.nixos-hardware.nixosModules.common-cpu-amd-pstate
+    flake-inputs.nixos-hardware.nixosModules.common-gpu-nvidia-nonprime
 
     ./hardware-configuration.nix
   ];
@@ -58,8 +59,6 @@ in {
     # Allow barrier
     firewall.allowedTCPPorts = [24800];
   };
-
-  services.xserver.videoDrivers = ["nvidia"];
 
   hardware = {
     nvidia.modesetting.enable = true;

--- a/nixos-config/yui/default.nix
+++ b/nixos-config/yui/default.nix
@@ -3,7 +3,9 @@
   lib,
   flake-inputs,
   ...
-}: {
+}: let
+  kernel = flake-inputs.nixpkgs-unfree.legacyPackages.${pkgs.system}.linuxPackages_latest;
+in {
   imports = [
     flake-inputs.nixos-hardware.nixosModules.common-pc
     flake-inputs.nixos-hardware.nixosModules.common-pc-ssd
@@ -29,6 +31,8 @@
       # by motherboard.
       "sp5100_tco"
     ];
+
+    kernelPackages = lib.mkForce kernel;
 
     initrd = {
       availableKernelModules = ["hid_roccat_ryos"];


### PR DESCRIPTION
I might be able to revert this if https://github.com/NixOS/nixpkgs/pull/195843 is merged before 22.11, but in the mean time...