### PR TITLE
mpd: Explicitly set output to pipewire

### DIFF
--- a/home-config/config/desktop/ncmpcpp.nix
+++ b/home-config/config/desktop/ncmpcpp.nix
@@ -16,6 +16,13 @@
       enable = true;
       musicDirectory = config.xdg.userDirs.music;
       network.startWhenNeeded = true;
+
+      extraConfig = ''
+        audio_output {
+          type "pipewire"
+          name "Pipewire"
+        }
+      '';
     };
   };
 }


### PR DESCRIPTION
Previously the alsa output used to work, seems that's no longer the
case.