### PR TITLE
Update to NixOS 23.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,20 +69,19 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "utils": "utils"
+        ]
       },
       "locked": {
-        "lastModified": 1681092193,
-        "narHash": "sha256-JerCqqOqbT2tBnXQW4EqwFl0hHnuZp21rIQ6lu/N4rI=",
+        "lastModified": 1685599623,
+        "narHash": "sha256-Tob4CMOVHue0D3RzguDBCtUmX5ji2PsdbQDbIOIKvsc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f9edbedaf015013eb35f8caacbe0c9666bbc16af",
+        "rev": "93db05480c0c0f30382d3e80779e8386dcb4f9dd",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-22.11",
+        "ref": "release-23.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -220,16 +219,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1684398685,
-        "narHash": "sha256-TRE62m91iZ5ArVMgA+uj22Yda8JoQuuhc9uwZ+NoX+0=",
+        "lastModified": 1685533922,
+        "narHash": "sha256-y4FCQpYafMQ42l1V+NUrMel9RtFtZo59PzdzflKR/lo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "628d4bb6e9f4f0c30cfd9b23d3c1cdcec9d3cb5c",
+        "rev": "3a70dd92993182f8e514700ccf5b1ae9fc8a3b8d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -343,21 +342,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     # NixOS related inputs
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs-unfree = {
       url = "github:numtide/nixpkgs-unfree";
@@ -28,7 +28,7 @@
 
     # home-manager related inputs
     home-manager = {
-      url = "github:nix-community/home-manager/release-22.11";
+      url = "github:nix-community/home-manager/release-23.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     nurpkgs.url = "github:nix-community/NUR";

--- a/home-config/config/desktop/hyprland.nix
+++ b/home-config/config/desktop/hyprland.nix
@@ -58,7 +58,7 @@ in {
       };
 
       Service = {
-        ExecStart = "${flake-inputs.nixpkgs-unstable.legacyPackages.${pkgs.system}.wpaperd}/bin/wpaperd --no-daemon";
+        ExecStart = "${pkgs.wpaperd}/bin/wpaperd --no-daemon";
         Environment = "XDG_CONFIG_HOME=${wpaperd-config-dir}";
       };
 

--- a/home-config/config/graphical-applications/default.nix
+++ b/home-config/config/graphical-applications/default.nix
@@ -18,7 +18,7 @@
       apvlv
       feh
       xsel
-      yubioath-desktop
+      yubioath-flutter
     ];
 
     xdg.configFile."alacritty/alacritty.yml".source = "${config._dotfiles}/alacritty/alacritty.yml";

--- a/home-config/config/graphical-applications/firefox.nix
+++ b/home-config/config/graphical-applications/firefox.nix
@@ -39,26 +39,27 @@ in {
     programs.firefox = {
       enable = true;
       package = pkgs.firefox.override {cfg.enableTridactylNative = true;};
-      extensions = with pkgs.nur.repos.rycee.firefox-addons; [
-        buster-captcha-solver
-        clearurls
-        decentraleyes
-        libredirect
-        no-pdf-download
-        react-devtools
-        reduxdevtools
-        translate-web-pages
-        tridactyl
-        ublock-origin
-
-        # # Missing:
-        # aria2-integration
-        # cloudhole
-        # devtools-adb-extension
-        # firefox-sticky-window-containers
-        # keepassxc-browser
-      ];
       profiles."tlater" = {
+        extensions = with pkgs.nur.repos.rycee.firefox-addons; [
+          buster-captcha-solver
+          clearurls
+          decentraleyes
+          libredirect
+          no-pdf-download
+          react-devtools
+          reduxdevtools
+          translate-web-pages
+          tridactyl
+          ublock-origin
+
+          # # Missing:
+          # aria2-integration
+          # cloudhole
+          # devtools-adb-extension
+          # firefox-sticky-window-containers
+          # keepassxc-browser
+        ];
+
         userChrome =
           builtins.readFile "${firefox-ui-fix}/css/leptonChrome.css";
         userContent =

--- a/home-config/config/graphical-applications/firefox.nix
+++ b/home-config/config/graphical-applications/firefox.nix
@@ -41,9 +41,11 @@ in {
       package = pkgs.firefox.override {cfg.enableTridactylNative = true;};
       profiles."tlater" = {
         extensions = with pkgs.nur.repos.rycee.firefox-addons; [
+          aria2-integration
           buster-captcha-solver
           clearurls
           decentraleyes
+          keepassxc-browser
           libredirect
           no-pdf-download
           react-devtools
@@ -53,11 +55,9 @@ in {
           ublock-origin
 
           # # Missing:
-          # aria2-integration
           # cloudhole
           # devtools-adb-extension
           # firefox-sticky-window-containers
-          # keepassxc-browser
         ];
 
         userChrome =

--- a/home-config/config/graphical-applications/keepassxc.nix
+++ b/home-config/config/graphical-applications/keepassxc.nix
@@ -44,6 +44,7 @@ in {
     systemd.user.timers.keepass-sync = {
       Unit.Description = "Periodic KeepassXC synchronization";
       Timer.OnCalendar = "hourly";
+      Install.WantedBy = ["timers.target"];
     };
   };
 }

--- a/home-config/config/tty-applications/emacs.nix
+++ b/home-config/config/tty-applications/emacs.nix
@@ -28,6 +28,8 @@ in {
     # Required for markdown-mode (though could be replaced with a
     # different markdown implementation at some point)
     pandoc
+
+    sqlite.dev
   ];
 
   xdg.configFile."emacs" = {

--- a/home-config/config/tty-applications/emacs.nix
+++ b/home-config/config/tty-applications/emacs.nix
@@ -13,7 +13,8 @@ in {
     # Used for interactive python shells
     python3Packages.ipython
 
-    # Needed for magit-lfs
+    # Needed for magit
+    git
     git-lfs
 
     # *.nix files are used to pull in project deps, so we always need these

--- a/home-config/dotfiles/emacs.d/config/editing.el
+++ b/home-config/dotfiles/emacs.d/config/editing.el
@@ -242,8 +242,8 @@
   (undo-fu-session-compression 'xz)
   (undo-fu-session-file-limit 20)
   :preface
-  (declare-function global-undo-fu-session-mode "undo-fu-session.el")
+  (declare-function undo-fu-session-global-mode "undo-fu-session.el")
   :config
-  (global-undo-fu-session-mode 1))
+  (undo-fu-session-global-mode 1))
 
 ;;; editing.el ends here

--- a/home-config/dotfiles/emacs.d/config/features.el
+++ b/home-config/dotfiles/emacs.d/config/features.el
@@ -87,6 +87,7 @@
   (transient-history-file (expand-file-name "transient/history.el" data-dir)))
 (use-package magit-lfs
   :after magit)
+(use-package sqlite3)                   ; Required for forge
 (use-package forge
   :after magit
   :custom

--- a/home-config/dotfiles/emacs.d/config/programming-languages.el
+++ b/home-config/dotfiles/emacs.d/config/programming-languages.el
@@ -375,7 +375,11 @@
     (reformatter-define clang-format
       :program "clang-format"
       :group 'glsl-mode
-      :lighter " CF")))
+      :lighter " CF")
+    (reformatter-define latexindent
+      :program "latexindent"
+      :group 'latex-mode
+      :lighter " LF")))
 
 (defcustom use-nixfmt nil
   "Use nixfmt for formatting nix instead of alejandra."
@@ -392,6 +396,8 @@
                  (alejandra-format-buffer)))
     ('glsl-mode
      (clang-format-buffer))
+    ('latex-mode
+     (latexindent-buffer))
     ((or 'mhtml-mode 'web-mode 'scss-mode)
      (prettier-js))
     ('haskell-mode (haskell-mode-stylish-buffer))

--- a/home-config/dotfiles/emacs.d/config/programming-languages.el
+++ b/home-config/dotfiles/emacs.d/config/programming-languages.el
@@ -357,7 +357,9 @@
   :commands (alejandra-format-region
              alejandra-format-buffer
              clang-format-region
-             clang-format-buffer)
+             clang-format-buffer
+             latexindent-format-region
+             latexindent-format-buffer)
   :config
   ;; Work around `make-variable-buffer-local' being called at a
   ;; non-top-level.
@@ -397,7 +399,7 @@
     ('glsl-mode
      (clang-format-buffer))
     ('latex-mode
-     (latexindent-buffer))
+     (latexindent-format-buffer))
     ((or 'mhtml-mode 'web-mode 'scss-mode)
      (prettier-js))
     ('haskell-mode (haskell-mode-stylish-buffer))

--- a/nixos-config/default.nix
+++ b/nixos-config/default.nix
@@ -74,7 +74,7 @@
   };
 
   boot = {
-    cleanTmpDir = true;
+    tmp.cleanOnBoot = true;
     plymouth.enable = true;
     kernelPackages = pkgs.linuxPackages_latest;
 

--- a/pkgs/applications/nextcloudcmd.nix
+++ b/pkgs/applications/nextcloudcmd.nix
@@ -23,11 +23,13 @@ stdenv.mkDerivation {
     libsForQt5.qtbase
     libsForQt5.qtkeychain
     libsForQt5.qtwebsockets
+    libsForQt5.qtwebengine
   ];
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DBUILD_UPDATER=off"
     "-DBUILD_GUI=off"
+    "-DBUILD_SHELL_INTEGRATION=off"
   ];
 }


### PR DESCRIPTION
This updates to NixOS 23.05, and also:

- Enables keepassxc synchronization
- Sets up auto-formatting for latex
- Installs the newly available Firefox add-ons declaratively
- Finally fixes magit-forge by installing the sqlite3 emacs package