### PR TITLE
WIP: nvidia: Fix Firefox not being able to use WebGL

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686693375,
-        "narHash": "sha256-1Smjo0E8WI9PeVGmmCjpQWRX04aQvz5gAGXfdanIjgw=",
+        "lastModified": 1685599623,
+        "narHash": "sha256-Tob4CMOVHue0D3RzguDBCtUmX5ji2PsdbQDbIOIKvsc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "61e5d1c38ef04ba30a9119825b159bce9c6010be",
+        "rev": "93db05480c0c0f30382d3e80779e8386dcb4f9dd",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1686933914,
-        "narHash": "sha256-b/HfW4lGK8lkIZVvFVgd9EkR2lmhX2VIJyncnJcVl8I=",
+        "lastModified": 1685729674,
+        "narHash": "sha256-i5+/bAZVmCbeIKmnwyd2DG3mGrP4LOJWbsU7nJ1lzuA=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "5ac625d7bdff6b6318058f396f0fa1641bb6e807",
+        "rev": "871ab24c6e9d2fb6e48cbf990ddddf0c46a950af",
         "type": "github"
       },
       "original": {
@@ -156,11 +156,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686925761,
-        "narHash": "sha256-H+i0VQvc2gx/QUCRNFoLZmHmCDITMQiF9zkDLj0pYCc=",
+        "lastModified": 1684479483,
+        "narHash": "sha256-NCkOkgR7PtkAQmYgeYd6vOzkulQjxlf+vWGUmrQu4uw=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "fd07e8b82042c0d2ca0c492df2b8f4854573c7d0",
+        "rev": "805bedf51a2f75a2279b6fc75b3066ff21f235ee",
         "type": "github"
       },
       "original": {
@@ -250,11 +250,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1686838567,
-        "narHash": "sha256-aqKCUD126dRlVSKV6vWuDCitfjFrZlkwNuvj5LtjRRU=",
+        "lastModified": 1684899633,
+        "narHash": "sha256-NtwerXX8UFsoNy6k+DukJMriWtEjQtMU/Urbff2O2Dg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "429f232fe1dc398c5afea19a51aad6931ee0fb89",
+        "rev": "4cc688ee711159b9bcb5a367be44007934e1a49d",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686592866,
-        "narHash": "sha256-riGg89eWhXJcPNrQGcSwTEEm7CGxWC06oSX44hajeMw=",
+        "lastModified": 1685931219,
+        "narHash": "sha256-8EWeOZ6LKQfgAjB/USffUSELPRjw88A+xTcXnOUvO5M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0eeebd64de89e4163f4d3cf34ffe925a5cf67a05",
+        "rev": "7409480d5c8584a1a83c422530419efe4afb0d19",
         "type": "github"
       },
       "original": {
@@ -327,27 +327,27 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1686869522,
-        "narHash": "sha256-tbJ9B8WLCTnVP/LwESRlg0dII6Zyg2LmUU/mB9Lu98E=",
+        "lastModified": 1686050451,
+        "narHash": "sha256-CzUQ5Y67tYCkvjGsL2rk51WnQJBTFry4lrmFFQ1vt9s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7c67f006ea0e7d0265f16d7df07cc076fdffd91f",
+        "rev": "aa5acfed2758882ee14ae79ce506d9459552a1b9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "rev": "aa5acfed2758882ee14ae79ce506d9459552a1b9",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1686921029,
-        "narHash": "sha256-J1bX9plPCFhTSh6E3TWn9XSxggBh/zDD4xigyaIQBy8=",
+        "lastModified": 1685620773,
+        "narHash": "sha256-iQ+LmporQNdLz8uMJdP62TaAWeLUwl43/MYUBtWqulM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c7ff1b9b95620ce8728c0d7bd501c458e6da9e04",
+        "rev": "f0ba8235153dd2e25cf06cbf70d43efdd4443592",
         "type": "github"
       },
       "original": {
@@ -359,11 +359,11 @@
     },
     "nurpkgs": {
       "locked": {
-        "lastModified": 1686962391,
-        "narHash": "sha256-Boqs2a6pkejQFUdF/oy+ej9UlxzGba6XXVk6MTL51HM=",
+        "lastModified": 1685752884,
+        "narHash": "sha256-2OvX7nU9OI+/5Trsdnf7Z0qzWca0601fLmfKUCOzM9Y=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0a03cc18199d3b64460c2611c65387072155d2f5",
+        "rev": "b9b4c6c683b344fe0990c18f22f20530d8cf5e81",
         "type": "github"
       },
       "original": {
@@ -444,11 +444,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686902322,
-        "narHash": "sha256-Vogj2MsipA+Uzr0M3d8300JeKQDHhPy6NEuTQXVdWu0=",
+        "lastModified": 1685434555,
+        "narHash": "sha256-aZl0yeaYX3T2L3W3yXOd3S9OfpS+8YUOT2b1KwrSf6E=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "1e2bae54870a06aa9364f8d33a5b9a0869d792fc",
+        "rev": "876846cde9762ae563f018c17993354875e2538e",
         "type": "github"
       },
       "original": {
@@ -497,11 +497,11 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1686753331,
-        "narHash": "sha256-KovjVFwcuoUO0eu/UiWrnD3+m/K+SHSAVIz4xF9K1XA=",
+        "lastModified": 1685723274,
+        "narHash": "sha256-mjETVZbVheaSO0VRKQHWYAHcoKwYu0WZ0vhKVN7vyRo=",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "7e7633abf09b362d0bad9e3fc650fd692369291d",
+        "rev": "6668c822b3bf58ca5af5d370ef03b075be3e4d27",
         "type": "gitlab"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1688192584,
+        "narHash": "sha256-mPexMc9nfCJSvTAoIrzNpBMNnX9FfeevTHqes4wjbSE=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "1b25873f884bb9db4924d98b3ec46a378ed60920",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -419,6 +440,7 @@
     "root": {
       "inputs": {
         "disko": "disko",
+        "fenix": "fenix",
         "home-manager": "home-manager",
         "hyprland": "hyprland",
         "hyprland-contrib": "hyprland-contrib",
@@ -432,6 +454,23 @@
         "nvfetcher": "nvfetcher",
         "peerix": "peerix",
         "sops-nix": "sops-nix"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1688155926,
+        "narHash": "sha256-DDikXFWmvRvGNTB8gqTrOLiITHlaW+40wMqVETuPyNQ=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "46cd8b849590a18c3e4f2eb8a0ade486d1c855a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "sops-nix": {

--- a/flake.lock
+++ b/flake.lock
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685599623,
-        "narHash": "sha256-Tob4CMOVHue0D3RzguDBCtUmX5ji2PsdbQDbIOIKvsc=",
+        "lastModified": 1686693375,
+        "narHash": "sha256-1Smjo0E8WI9PeVGmmCjpQWRX04aQvz5gAGXfdanIjgw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "93db05480c0c0f30382d3e80779e8386dcb4f9dd",
+        "rev": "61e5d1c38ef04ba30a9119825b159bce9c6010be",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1685729674,
-        "narHash": "sha256-i5+/bAZVmCbeIKmnwyd2DG3mGrP4LOJWbsU7nJ1lzuA=",
+        "lastModified": 1686933914,
+        "narHash": "sha256-b/HfW4lGK8lkIZVvFVgd9EkR2lmhX2VIJyncnJcVl8I=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "871ab24c6e9d2fb6e48cbf990ddddf0c46a950af",
+        "rev": "5ac625d7bdff6b6318058f396f0fa1641bb6e807",
         "type": "github"
       },
       "original": {
@@ -156,11 +156,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684479483,
-        "narHash": "sha256-NCkOkgR7PtkAQmYgeYd6vOzkulQjxlf+vWGUmrQu4uw=",
+        "lastModified": 1686925761,
+        "narHash": "sha256-H+i0VQvc2gx/QUCRNFoLZmHmCDITMQiF9zkDLj0pYCc=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "805bedf51a2f75a2279b6fc75b3066ff21f235ee",
+        "rev": "fd07e8b82042c0d2ca0c492df2b8f4854573c7d0",
         "type": "github"
       },
       "original": {
@@ -250,11 +250,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1684899633,
-        "narHash": "sha256-NtwerXX8UFsoNy6k+DukJMriWtEjQtMU/Urbff2O2Dg=",
+        "lastModified": 1686838567,
+        "narHash": "sha256-aqKCUD126dRlVSKV6vWuDCitfjFrZlkwNuvj5LtjRRU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4cc688ee711159b9bcb5a367be44007934e1a49d",
+        "rev": "429f232fe1dc398c5afea19a51aad6931ee0fb89",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685655444,
-        "narHash": "sha256-6EujQNAeaUkWvpEZZcVF8qSfQrNVWFNNGbUJxv/A5a8=",
+        "lastModified": 1686592866,
+        "narHash": "sha256-riGg89eWhXJcPNrQGcSwTEEm7CGxWC06oSX44hajeMw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e635192892f5abbc2289eaac3a73cdb249abaefd",
+        "rev": "0eeebd64de89e4163f4d3cf34ffe925a5cf67a05",
         "type": "github"
       },
       "original": {
@@ -327,11 +327,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1685655444,
-        "narHash": "sha256-6EujQNAeaUkWvpEZZcVF8qSfQrNVWFNNGbUJxv/A5a8=",
+        "lastModified": 1686869522,
+        "narHash": "sha256-tbJ9B8WLCTnVP/LwESRlg0dII6Zyg2LmUU/mB9Lu98E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e635192892f5abbc2289eaac3a73cdb249abaefd",
+        "rev": "7c67f006ea0e7d0265f16d7df07cc076fdffd91f",
         "type": "github"
       },
       "original": {
@@ -343,11 +343,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1685620773,
-        "narHash": "sha256-iQ+LmporQNdLz8uMJdP62TaAWeLUwl43/MYUBtWqulM=",
+        "lastModified": 1686921029,
+        "narHash": "sha256-J1bX9plPCFhTSh6E3TWn9XSxggBh/zDD4xigyaIQBy8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f0ba8235153dd2e25cf06cbf70d43efdd4443592",
+        "rev": "c7ff1b9b95620ce8728c0d7bd501c458e6da9e04",
         "type": "github"
       },
       "original": {
@@ -359,11 +359,11 @@
     },
     "nurpkgs": {
       "locked": {
-        "lastModified": 1685752884,
-        "narHash": "sha256-2OvX7nU9OI+/5Trsdnf7Z0qzWca0601fLmfKUCOzM9Y=",
+        "lastModified": 1686962391,
+        "narHash": "sha256-Boqs2a6pkejQFUdF/oy+ej9UlxzGba6XXVk6MTL51HM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9b4c6c683b344fe0990c18f22f20530d8cf5e81",
+        "rev": "0a03cc18199d3b64460c2611c65387072155d2f5",
         "type": "github"
       },
       "original": {
@@ -444,11 +444,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685434555,
-        "narHash": "sha256-aZl0yeaYX3T2L3W3yXOd3S9OfpS+8YUOT2b1KwrSf6E=",
+        "lastModified": 1686902322,
+        "narHash": "sha256-Vogj2MsipA+Uzr0M3d8300JeKQDHhPy6NEuTQXVdWu0=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "876846cde9762ae563f018c17993354875e2538e",
+        "rev": "1e2bae54870a06aa9364f8d33a5b9a0869d792fc",
         "type": "github"
       },
       "original": {
@@ -497,11 +497,11 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1685723274,
-        "narHash": "sha256-mjETVZbVheaSO0VRKQHWYAHcoKwYu0WZ0vhKVN7vyRo=",
+        "lastModified": 1686753331,
+        "narHash": "sha256-KovjVFwcuoUO0eu/UiWrnD3+m/K+SHSAVIz4xF9K1XA=",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "6668c822b3bf58ca5af5d370ef03b075be3e4d27",
+        "rev": "7e7633abf09b362d0bad9e3fc650fd692369291d",
         "type": "gitlab"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,7 @@
     nixpkgs,
     home-manager,
     sops-nix,
+    nvfetcher,
     ...
   } @ inputs: {
     nixosConfigurations = {
@@ -124,6 +125,7 @@
     in
       nixpkgs.legacyPackages.x86_64-linux.mkShell {
         packages = [
+          nvfetcher.packages.x86_64-linux.default
           commit-nvfetcher
           home-manager-bin
           sops-init-gpg-key

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     # NixOS related inputs
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
-    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/aa5acfed2758882ee14ae79ce506d9459552a1b9";
     nixpkgs-unfree = {
       url = "github:numtide/nixpkgs-unfree";
       inputs.nixpkgs.follows = "nixpkgs-unstable";

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     nurpkgs.url = "github:nix-community/NUR";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     # Other project inputs
     nvfetcher = {

--- a/home-config/config/graphical-applications/firefox.nix
+++ b/home-config/config/graphical-applications/firefox.nix
@@ -68,6 +68,7 @@ in {
           # Performance settings
           "gfx.webrender.all" = true; # Force enable GPU acceleration
           "media.ffmpeg.vaapi.enabled" = true;
+          "widget.dmabuf.force-enabled" = true; # Required in recent Firefoxes
 
           # Re-bind ctrl to super (would interfere with tridactyl otherwise)
           "ui.key.accelKey" = 91;

--- a/nixos-config/default.nix
+++ b/nixos-config/default.nix
@@ -21,9 +21,13 @@
     settings = {
       auto-optimise-store = true;
       experimental-features = ["nix-command" "flakes"];
-      substituters = ["https://hyprland.cachix.org"];
+      substituters = [
+        "https://hyprland.cachix.org"
+        "https://nix-community.cachix.org"
+      ];
       trusted-public-keys = [
         "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
+        "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
         (builtins.readFile ../keys/peerix/yui.pub)
       ];
     };

--- a/nixos-config/greeter/default.nix
+++ b/nixos-config/greeter/default.nix
@@ -31,6 +31,7 @@
     name = "launch-gtkgreet";
     runtimeInputs = [
       flake-inputs.hyprland.packages.${pkgs.system}.hyprland-nvidia
+      pkgs.hypr
       pkgs.greetd.gtkgreet
       pkgs.eww-wayland
     ];
@@ -44,6 +45,11 @@
     export XDG_SESSION_TYPE=wayland
     systemd-cat -t xsession Hyprland
   '';
+
+  hypr = pkgs.writeShellScriptBin "hypr-run" ''
+    export XDG_SESSION_TYPE=x11
+    ${config.services.xserver.displayManager.sessionData.wrapper} ${pkgs.hypr}/bin/Hypr
+  '';
 in {
   services.xserver.displayManager.lightdm.enable = false;
 
@@ -56,6 +62,7 @@ in {
 
   environment.systemPackages = with pkgs; [
     eww-wayland
+    hypr
     hyprland
     pciutils
   ];
@@ -66,6 +73,7 @@ in {
 
   environment.etc."greetd/environments".text = ''
     hyprland-run
+    hypr-run
   '';
 
   systemd.tmpfiles.rules = let
@@ -73,13 +81,5 @@ in {
   in [
     "d /var/log/gtkgreet 0755 greeter ${user} - -"
     "d /var/cache/gtkgreet 0755 greeter ${user} - -"
-  ];
-
-  services.xserver.displayManager.session = [
-    {
-      manage = "desktop";
-      name = "user-defined";
-      start = config.services.xserver.displayManager.sessionData.wrapper;
-    }
   ];
 }

--- a/nixos-config/yui/default.nix
+++ b/nixos-config/yui/default.nix
@@ -13,6 +13,7 @@ in {
     flake-inputs.nixos-hardware.nixosModules.common-cpu-amd-pstate
     flake-inputs.nixos-hardware.nixosModules.common-gpu-nvidia-nonprime
 
+    ./games.nix
     ./hardware-configuration.nix
     ../networks/personal.nix
     ./wireguard.nix
@@ -22,6 +23,8 @@ in {
 
   nixpkgs.config.allowUnfreePredicate = pkg:
     builtins.elem (pkgs.lib.getName pkg) [
+      "steam"
+      "steam-run"
       # Required to get the steam controller to work (i.e., for hardware.steam-hardware)
       "steam-original"
       "nvidia-x11"
@@ -39,9 +42,6 @@ in {
     ];
 
     kernelPackages = lib.mkForce flake-inputs.nixpkgs-unfree.legacyPackages.${pkgs.system}.linuxPackages_latest;
-
-    # Star citizen needs more
-    kernel.sysctl."vm.max_map_count" = 16777216;
 
     initrd.luks.devices = let
       ssdOptimization = {
@@ -91,10 +91,6 @@ in {
     ''ATTR{device}=="0x1483"''
     ''ATTR{power/wakeup}="disabled"''
   ];
-
-  # Make steam controller work
-  hardware.steam-hardware.enable = true;
-  services.joycond.enable = true;
 
   # For random android-related things
   programs.adb.enable = true;

--- a/nixos-config/yui/games.nix
+++ b/nixos-config/yui/games.nix
@@ -1,0 +1,24 @@
+{
+  # Make steam controller work
+  hardware.steam-hardware.enable = true;
+  services.joycond.enable = true;
+
+  programs.steam.enable = true;
+  programs.gamescope = {
+    enable = true;
+    capSysNice = true;
+    args = [
+      "--steam"
+      "--expose-wayland"
+      "--rt"
+      "-W 1920"
+      "-H 1080"
+      "--force-grab-cursor"
+      "--grab"
+      "--fullscreen"
+    ];
+  };
+
+  # Star citizen needs more
+  boot.kernel.sysctl."vm.max_map_count" = 16777216;
+}

--- a/nixos-config/yui/nvidia.nix
+++ b/nixos-config/yui/nvidia.nix
@@ -12,6 +12,24 @@
     powerManagement.enable = true;
   };
 
+  boot.extraModprobeConfig =
+    "options nvidia "
+    + lib.concatStringsSep " " [
+      # nvidia assume that by default your CPU does not support PAT,
+      # but this is effectively never the case in 2023
+      "NVreg_UsePageAttributeTable=1"
+      # This may be a noop, but it's somewhat uncertain
+      "NVreg_EnablePCIeGen3=1"
+      # This is sometimes needed for ddc/ci support, see
+      # https://www.ddcutil.com/nvidia/
+      #
+      # Current monitor does not support it, but this is useful for
+      # the future
+      "NVreg_RegistryDwords=RMUseSwI2c=0x01;RMI2cSpeed=100"
+      # When (if!) I get another nvidia GPU, check for resizeable bar
+      # settings
+    ];
+
   environment.variables = {
     # Necessary to correctly enable va-api (video codec hardware
     # acceleration). If this isn't set, the libvdpau backend will be

--- a/nixos-config/yui/nvidia.nix
+++ b/nixos-config/yui/nvidia.nix
@@ -1,4 +1,10 @@
 {
+  config,
+  flake-inputs,
+  lib,
+  pkgs,
+  ...
+}: {
   hardware.nvidia = {
     modesetting.enable = true;
     # Power management is required to get nvidia GPUs to behave on
@@ -26,4 +32,30 @@
   };
 
   programs.hyprland.nvidiaPatches = true;
+
+  # Ugly hack to fix a bug in egl-wayland, see
+  # https://github.com/NixOS/nixpkgs/issues/202454
+  environment.etc."egl/egl_external_platform.d".source = let
+    nvidia_wayland = pkgs.writeText "10_nvidia_wayland.json" ''
+      {
+          "file_format_version" : "1.0.0",
+          "ICD" : {
+              "library_path" : "${flake-inputs.nixpkgs-unstable.legacyPackages.${pkgs.system}.egl-wayland}/lib/libnvidia-egl-wayland.so"
+          }
+      }
+    '';
+    nvidia_gbm = pkgs.writeText "15_nvidia_gbm.json" ''
+      {
+          "file_format_version" : "1.0.0",
+          "ICD" : {
+              "library_path" : "${config.hardware.nvidia.package}/lib/libnvidia-egl-gbm.so.1"
+          }
+      }
+    '';
+  in
+    lib.mkForce (pkgs.runCommandLocal "nvidia-egl-hack" {} ''
+      mkdir -p $out
+      cp ${nvidia_wayland} $out/10_nvidia_wayland.json
+      cp ${nvidia_gbm} $out/15_nvidia_gbm.json
+    '');
 }

--- a/nixos-config/yui/nvidia.nix
+++ b/nixos-config/yui/nvidia.nix
@@ -29,6 +29,8 @@
     # Required to use va-api it in Firefox. See
     # https://github.com/elFarto/nvidia-vaapi-driver/issues/96
     MOZ_DISABLE_RDD_SANDBOX = "1";
+    NVD_BACKEND = "direct"; #
+    EGL_PLATFORM = "wayland"; #
   };
 
   programs.hyprland.nvidiaPatches = true;

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -19,6 +19,26 @@
         },
         "version": "v1.5.3"
     },
+    "deepfilternet": {
+        "cargoLocks": null,
+        "date": null,
+        "extract": null,
+        "name": "deepfilternet",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "Rikorose",
+            "repo": "DeepFilterNet",
+            "rev": "v0.5.0",
+            "sha256": "sha256-q+SB6lxDd7V+UJW5WCGu0xfDIq4IFUQR6l4R4/lozmE=",
+            "type": "github"
+        },
+        "version": "v0.5.0"
+    },
     "firefox-ui-fix": {
         "cargoLocks": null,
         "date": "2023-06-15",

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -21,7 +21,7 @@
     },
     "firefox-ui-fix": {
         "cargoLocks": null,
-        "date": "2023-05-29",
+        "date": "2023-06-15",
         "extract": null,
         "name": "firefox-ui-fix",
         "passthru": null,
@@ -33,11 +33,11 @@
             "name": null,
             "owner": "black7375",
             "repo": "Firefox-UI-Fix",
-            "rev": "396f06b45c4bf33fd2b68ddf86373395b95b4401",
-            "sha256": "sha256-XYHME+ByUNdGEi8iMrfOXVp98AbTWRU2VHFyDCt8Hp0=",
+            "rev": "4ee131b29b5e52cd0da09cfb5a61d81838e5be9c",
+            "sha256": "sha256-ks17bMC/I/Mqg4s5utnRIJ+UvwpCnXw8e10ApTCbsJI=",
             "type": "github"
         },
-        "version": "396f06b45c4bf33fd2b68ddf86373395b95b4401"
+        "version": "4ee131b29b5e52cd0da09cfb5a61d81838e5be9c"
     },
     "gauth": {
         "cargoLocks": null,
@@ -61,7 +61,7 @@
     },
     "ohmyzsh": {
         "cargoLocks": null,
-        "date": "2023-06-02",
+        "date": "2023-06-16",
         "extract": null,
         "name": "ohmyzsh",
         "passthru": null,
@@ -73,11 +73,11 @@
             "name": null,
             "owner": "ohmyzsh",
             "repo": "ohmyzsh",
-            "rev": "6101106916147b1716ff2d5de4a53260e7607bae",
-            "sha256": "sha256-0ACCQfeV9oMQCcGEtp3XaMuQxjNQWhrQn5AiX9AWazg=",
+            "rev": "42b86327ed875ee182f8fc394b90ae9328a5ac00",
+            "sha256": "sha256-dWDOuxtFqrCO0dwQ+kXgPwrLegdBRrqOxhFKqe2SFLs=",
             "type": "github"
         },
-        "version": "6101106916147b1716ff2d5de4a53260e7607bae"
+        "version": "42b86327ed875ee182f8fc394b90ae9328a5ac00"
     },
     "phosphor-icons": {
         "cargoLocks": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -12,6 +12,17 @@
       sha256 = "sha256-IBzX7WASluoxXVdWkoJHRIQQF4Fi7IJOvRfRl+W3YZI=";
     };
   };
+  deepfilternet = {
+    pname = "deepfilternet";
+    version = "v0.5.0";
+    src = fetchFromGitHub {
+      owner = "Rikorose";
+      repo = "DeepFilterNet";
+      rev = "v0.5.0";
+      fetchSubmodules = false;
+      sha256 = "sha256-q+SB6lxDd7V+UJW5WCGu0xfDIq4IFUQR6l4R4/lozmE=";
+    };
+  };
   firefox-ui-fix = {
     pname = "firefox-ui-fix";
     version = "4ee131b29b5e52cd0da09cfb5a61d81838e5be9c";

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -14,15 +14,15 @@
   };
   firefox-ui-fix = {
     pname = "firefox-ui-fix";
-    version = "396f06b45c4bf33fd2b68ddf86373395b95b4401";
+    version = "4ee131b29b5e52cd0da09cfb5a61d81838e5be9c";
     src = fetchFromGitHub {
       owner = "black7375";
       repo = "Firefox-UI-Fix";
-      rev = "396f06b45c4bf33fd2b68ddf86373395b95b4401";
+      rev = "4ee131b29b5e52cd0da09cfb5a61d81838e5be9c";
       fetchSubmodules = false;
-      sha256 = "sha256-XYHME+ByUNdGEi8iMrfOXVp98AbTWRU2VHFyDCt8Hp0=";
+      sha256 = "sha256-ks17bMC/I/Mqg4s5utnRIJ+UvwpCnXw8e10ApTCbsJI=";
     };
-    date = "2023-05-29";
+    date = "2023-06-15";
   };
   gauth = {
     pname = "gauth";
@@ -37,15 +37,15 @@
   };
   ohmyzsh = {
     pname = "ohmyzsh";
-    version = "6101106916147b1716ff2d5de4a53260e7607bae";
+    version = "42b86327ed875ee182f8fc394b90ae9328a5ac00";
     src = fetchFromGitHub {
       owner = "ohmyzsh";
       repo = "ohmyzsh";
-      rev = "6101106916147b1716ff2d5de4a53260e7607bae";
+      rev = "42b86327ed875ee182f8fc394b90ae9328a5ac00";
       fetchSubmodules = false;
-      sha256 = "sha256-0ACCQfeV9oMQCcGEtp3XaMuQxjNQWhrQn5AiX9AWazg=";
+      sha256 = "sha256-dWDOuxtFqrCO0dwQ+kXgPwrLegdBRrqOxhFKqe2SFLs=";
     };
-    date = "2023-06-02";
+    date = "2023-06-16";
   };
   phosphor-icons = {
     pname = "phosphor-icons";

--- a/pkgs/applications/deepfilternet.nix
+++ b/pkgs/applications/deepfilternet.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  sources,
+  system,
+  flake-inputs,
+  makeRustPlatform,
+  symlinkJoin,
+  pkg-config,
+  fetchurl,
+  alsa-lib,
+  python3,
+  hdf5,
+}: let
+  # Need to use unstable rust platform until this is resolved:
+  # https://github.com/rust-lang/rust/issues/63292
+  rustPlatform = let
+    toolchain = flake-inputs.fenix.packages.${system}.minimal.toolchain;
+  in
+    makeRustPlatform {
+      cargo = toolchain;
+      rustc = toolchain;
+    };
+
+  hdf5-12 = hdf5.overrideAttrs (old: {
+    version = "1.12.2";
+
+    src = fetchurl {
+      url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.2/src/hdf5-1.12.2.tar.bz2";
+      sha256 = "sha256-Goi742ITos6gyDlyAaRZZD5xVcnckeBiZ1s/sH7jiv4=";
+    };
+
+    postFixup = ""; # The 1.14.0 derivation needs to patch some additional things
+  });
+in
+  rustPlatform.buildRustPackage {
+    inherit (sources.deepfilternet) pname version src;
+
+    buildInputs = [
+      alsa-lib
+    ];
+
+    nativeBuildInputs = [
+      pkg-config
+      python3
+    ];
+
+    HDF5_DIR = symlinkJoin {
+      name = "hdf5";
+      paths = [hdf5-12 hdf5-12.dev];
+    };
+
+    checkFlags = [
+      "--skip=reexport_dataset_modules::dataset::tests::test_hdf5_slice"
+    ];
+
+    cargoHash = lib.fakeHash;
+    cargoBuildFlags = ["--package deep-filter-ladspa"];
+    cargoLock = {
+      lockFile = "${sources.deepfilternet.src}/Cargo.lock";
+
+      # Upstream uses a version from a github PR for the moment, we can
+      # probably change this once it is merged.
+      #
+      # Incidentally, we should be able to remove the `lockFile`
+      # property in general once this happens.
+      outputHashes."hdf5-0.8.1" = "sha256-TQaIgu2ww/2HTaJC7q/lLWjTdSwIJ2G2RvO0WS5mfcM=";
+    };
+  }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -18,6 +18,7 @@ in {
   commit-nvfetcher = callPackage ./scripts/commit-nvfetcher {};
 
   # Proper packages
+  deepfilternet = callPackage ./applications/deepfilternet.nix {};
   emacs = callPackage ./applications/emacs {};
   gauth = callPackage ./applications/gauth.nix {};
   stumpwm = callPackage ./applications/stumpwm {};

--- a/pkgs/nvfetcher.toml
+++ b/pkgs/nvfetcher.toml
@@ -2,6 +2,10 @@
 src.github_tag = "matthewbauer/bauer"
 fetch.github = "matthewbauer/bauer"
 
+[deepfilternet]
+src.github = "Rikorose/DeepFilterNet"
+fetch.github = "Rikorose/DeepFilterNet"
+
 [firefox-ui-fix]
 src.git = "https://github.com/black7375/Firefox-UI-Fix"
 # For the time being, until this project figures out its releasening


### PR DESCRIPTION
This substitutes the default egl-wayland from the nvidia driver with
the version in nixpkgs/master, which includes a fix for something that
causes Firefox' graphics detection routine to crash.

The actual fix is not yet in nixpkgs-unstable, and even if it was this
is a very ugly solution.

Discussion on how to actually fix this continues in
https://github.com/NixOS/nixpkgs/issues/202454 , but it's my fix for
now.