### PR TITLE
emacs: Improve package consumption

### DIFF
--- a/home-config/config/applications/tty/emacs.nix
+++ b/home-config/config/applications/tty/emacs.nix
@@ -1,5 +1,6 @@
 { pkgs, flake-inputs, ... }:
 let
+  inherit (flake-inputs) self;
   inherit (flake-inputs.self.packages.${pkgs.system}) emacs;
   inherit (flake-inputs.nixd.packages.${pkgs.system}) nixd;
 in
@@ -43,7 +44,7 @@ in
     ];
 
   xdg.configFile."emacs" = {
-    source = emacs.dotfiles;
+    source = "${self}/home-config/dotfiles/emacs.d/";
     recursive = true;
   };
 

--- a/home-config/dotfiles/emacs.d/config/integration.el
+++ b/home-config/dotfiles/emacs.d/config/integration.el
@@ -25,7 +25,7 @@
 ;;; Code:
 
 (eval-and-compile
-  (require 'use-package))
+  (require 'leaf))
 
 ;; ----------------------------------------------------------------------------------
 ;;; User settings
@@ -38,59 +38,46 @@
 ;;; Authentication
 ;; ----------------------------------------------------------------------------------
 
-(use-package auth-source
-  :functions auth-sources
+(leaf auth-source
   :custom
-  (auth-sources '("secrets:Personal")))
+  (auth-sources . '("secrets:Personal")))
 
 ;; ----------------------------------------------------------------------------------
 ;;; External applications
 ;; ----------------------------------------------------------------------------------
 
-(use-package alert
-  :commands alert
-  :custom
-  (alert-default-style 'libnotify))
-
-(use-package browse-url
+(leaf browse-url
   :commands browse-url
   :custom
-  (browse-url-browser-function 'browse-url-default-browser))
+  (browse-url-browser-function . 'browse-url-default-browser))
 
-;; A nice UI for ripgrep when not used with project.el
-(use-package deadgrep
-  :commands deadgrep)
-
-(use-package direnv
-  :demand
-  :commands direnv-mode
-  :config
-  (direnv-mode))
+(leaf direnv
+  :global-minor-mode direnv-mode)
 
 ;; ----------------------------------------------------------------------------------
 ;;; XDG dirs
 ;; ----------------------------------------------------------------------------------
 
-(use-package eshell
+(leaf eshell
   :commands eshell
+  :defvar data-dir
   :custom
-  (eshell-directory-name (expand-file-name "eshell" data-dir)))
+  `(eshell-directory-name . ,(expand-file-name "eshell" data-dir)))
 
-(use-package recentf
-  :demand
-  :commands recentf-save-list
+(leaf recentf
+  :defun recentf-save-list
   :custom
-  (recentf-save-file (expand-file-name "recentf" data-dir))
+  `(recentf-save-file . ,(expand-file-name "recentf" data-dir))
   :config
   (add-hook 'delete-frame-functions (lambda (_) (recentf-save-list))))
 
-(use-package tramp
+(leaf tramp
   :custom
-  (tramp-persistency-file-name (expand-file-name "tramp" data-dir))
-  (tramp-default-method "scp"))
+  `(tramp-persistency-file-name . ,(expand-file-name "tramp" data-dir))
+  (tramp-default-method . "scp"))
 
-(use-package url
+(leaf url
   :custom
-  (url-configuration-directory (expand-file-name "url" data-dir)))
+  `(url-configuration-directory . ,(expand-file-name "url" data-dir)))
 
 ;;; integration.el ends here

--- a/home-config/dotfiles/emacs.d/config/programming-languages.el
+++ b/home-config/dotfiles/emacs.d/config/programming-languages.el
@@ -369,6 +369,13 @@
   (add-to-list 'eglot-server-programs
                '(nix-mode . ("nixd"))))
 
+(use-package eglot-x
+  :after eglot
+  :commands eglot-x-setup
+  :demand t
+  :config
+  (eglot-x-setup))
+
 (use-package flymake
   :hook (prog-mode . flymake-mode)
   :bind (:map flymake-mode-map

--- a/home-config/dotfiles/emacs.d/config/programming-languages.el
+++ b/home-config/dotfiles/emacs.d/config/programming-languages.el
@@ -249,8 +249,11 @@
 ;;; TypeScript (and other web-related DSLs)
 ;; ----------------------------------------------------------------------------------
 
+(leaf typescript-ts-mode
+  :mode `(,(rx ".ts" (? "x") string-end)))
+
 (leaf web-mode
-  :mode `(,(rx (or ".pug" ".hbs" (and ".ts" (? "x"))) string-end))
+  :mode `(,(rx (or ".pug" ".hbs") string-end))
   :hook (web-mode-hook . (lambda () (setq-local devdocs-current-docs
                                                 '("html"
                                                   "typescript"
@@ -345,9 +348,10 @@
                               (:checkOnSave
                                (:command "clippy")))))
   (add-to-list 'eglot-server-programs
-               `(web-mode . ,(eglot-alternatives
-                              '(("biome" "lsp-proxy")
-                                ("typescript-language-server" "--stdio")))))
+               `((typescript-ts-mode :language-id "typescriptreact")
+                 . ("typescript-language-server" "--stdio")))
+  (add-to-list 'eglot-server-programs
+               `(web-mode . ("biome" "lsp-proxy")))
   (add-to-list 'eglot-server-programs
                '(json-mode . ("biome" "lsp-proxy")))
   (add-to-list 'eglot-server-programs

--- a/home-config/dotfiles/emacs.d/config/programming-languages.el
+++ b/home-config/dotfiles/emacs.d/config/programming-languages.el
@@ -25,9 +25,7 @@
 ;;; Code:
 
 (eval-and-compile
-  (require 'use-package)
-  (defvar config-dir)
-  (defvar share-dir))
+  (require 'leaf))
 
 ;; ----------------------------------------------------------------------------------
 ;; ----------------------------------------------------------------------------------
@@ -39,221 +37,210 @@
 ;;; Bazel
 ;; ----------------------------------------------------------------------------------
 
-(use-package bazel
-  :mode (((rx ".bzl" string-end) . bazel-starlark-mode)
-         ((rx (or "BUILD" "BUILD.bazel") string-end) . bazel-build-mode))
+(leaf bazel
+  :mode `((,(rx ".bzl" string-end) . bazel-starlark-mode)
+         (,(rx (or "BUILD" "BUILD.bazel") string-end) . bazel-build-mode))
   :commands bazel-buildifier)
 
 ;; ----------------------------------------------------------------------------------
 ;;; CSV
 ;; ----------------------------------------------------------------------------------
 
-(use-package csv-mode
-  :mode (rx ".csv" string-end))
+(leaf csv-mode
+  :mode `(,(rx ".csv" string-end)))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Dockerfile
 ;; ----------------------------------------------------------------------------------
 
-(use-package dockerfile-mode
-  :mode (rx string-start "Dockerfile" string-end)
-  :hook (dockerfile-mode . (lambda () (setq-local devdocs-current-docs '("docker")))))
+(leaf dockerfile-mode
+  :mode `(,(rx string-start "Dockerfile" string-end))
+  :hook (dockerfile-mode-hook . (lambda () (setq-local devdocs-current-docs '("docker")))))
 
 ;; ----------------------------------------------------------------------------------
 ;;; GLSL
 ;; ----------------------------------------------------------------------------------
 
-(use-package glsl-mode
-  :mode (rx (or ".glsl" ".vert" ".frag" ".geom") string-end))
+(leaf glsl-mode
+  :mode `(,(rx (or ".glsl" ".vert" ".frag" ".geom") string-end)))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Gnuplot
 ;; ----------------------------------------------------------------------------------
 
-(use-package gnuplot
-  :mode ((rx (or ".p" ".gp" ".gnuplot") string-end) . gnuplot-mode)
-  :hook (gnuplot-mode . (lambda () (setq-local devdocs-current-docs '("gnuplot")))))
+(leaf gnuplot
+  :mode `(,(rx (or ".p" ".gp" ".gnuplot") string-end) . gnuplot-mode)
+  :hook (gnuplot-mode-hook . (lambda () (setq-local devdocs-current-docs '("gnuplot")))))
 
 ;; ----------------------------------------------------------------------------------
 ;;; GraphQL
 ;; ----------------------------------------------------------------------------------
 
-(use-package graphql-mode
-  :mode (rx (or ".graphql" ".gql") string-end))
+(leaf graphql-mode
+  :mode `(,(rx (or ".graphql" ".gql") string-end)))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Haskell
 ;; ----------------------------------------------------------------------------------
 
-(use-package haskell-mode
+(leaf haskell-mode
   :commands haskell-mode-stylish-buffer
-  :mode (rx ".hs" string-end)
-  :hook (haskell-mode . interactive-haskell-mode)
-  :hook (haskell-mode . (lambda () (setq-local devdocs-current-docs '("haskell~9"))))
-  :bind (:map haskell-mode-map
-              ("C-c `" . haskell-interactive-bring)))
+  :mode `(,(rx ".hs" string-end))
+  :hook (haskell-mode-hook . interactive-haskell-mode)
+  :hook (haskell-mode-hook . (lambda () (setq-local devdocs-current-docs '("haskell~9"))))
+  :bind (:haskell-mode-map
+         ("C-c `" . haskell-interactive-bring)))
 
 ;; ----------------------------------------------------------------------------------
 ;;; JSON & co.
 ;; ----------------------------------------------------------------------------------
 
-(use-package json-mode
-  :mode (rx ".json" string-end))
+(leaf json-mode
+  :mode `(,(rx ".json" string-end)))
 
-(use-package jsonnet-mode
-  :mode (rx ".jsonnet" string-end))
+(leaf jsonnet-mode
+  :mode `(,(rx ".jsonnet" string-end)))
 
-(use-package yaml-mode
-  :mode (rx (or ".yaml" ".yml" ".bst"
-                (and string-start "project.conf")) string-end))
+(leaf yaml-mode
+  :mode `(,(rx (or ".yaml" ".yml" ".bst"
+                (and string-start "project.conf")) string-end)))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Kotlin
 ;; ----------------------------------------------------------------------------------
 
-(use-package kotlin-mode
-  :hook (kotlin-mode . (lambda () (setq-local devdocs-current-docs '("kotlin~1.9"))))
-  :mode (rx ".kt" (optional "s") string-end))
+(leaf kotlin-mode
+  :hook (kotlin-mode-hook . (lambda () (setq-local devdocs-current-docs '("kotlin~1.9"))))
+  :mode `(,(rx ".kt" (optional "s") string-end)))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Markdown
 ;; ----------------------------------------------------------------------------------
 
-(use-package markdown-mode
-  :hook (markdown-mode . (lambda () (setq-local devdocs-current-docs '("markdown"))))
-  :mode (rx (or
+(leaf markdown-mode
+  :hook (markdown-mode-hook . (lambda () (setq-local devdocs-current-docs '("markdown"))))
+  :mode `(,(rx (or
              (and (or ".md" ".mdwn") string-end)
-             (and string-start "/tmp/neomutt-")))
+             (and string-start "/tmp/neomutt-"))))
   :custom
-  (markdown-command '("pandoc" "--from=markdown" "--to=html5")))
+  (markdown-command . '("pandoc" "--from=markdown" "--to=html5")))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Mermaid
 ;; ----------------------------------------------------------------------------------
 
-(use-package mermaid-mode
-  :mode (rx ".mermaid" string-end))
+(leaf mermaid-mode
+  :mode `(,(rx ".mermaid" string-end)))
 
 ;; ----------------------------------------------------------------------------------
 ;;; nginx config files
 ;; ----------------------------------------------------------------------------------
 
-(use-package nginx-mode
-  :mode (rx "nginx.conf" string-end)
-  :hook (markdown-mode . (lambda () (setq-local devdocs-current-docs '("nginx")))))
+(leaf nginx-mode
+  :mode `(,(rx "nginx.conf" string-end))
+  :hook (markdown-mode-hook . (lambda () (setq-local devdocs-current-docs '("nginx")))))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Nix
 ;; ----------------------------------------------------------------------------------
 
-(use-package nix-mode
-  :commands nix-format-buffer
-  :mode (rx ".nix" string-end)
-  :hook (nix-mode . (lambda () (setq-local devdocs-current-docs '("nix")))))
+(leaf nix-mode
+  :mode `(,(rx ".nix" string-end))
+  :hook (nix-mode-hook . (lambda () (setq-local devdocs-current-docs '("nix")))))
 
 ;; ----------------------------------------------------------------------------------
 ;;; org
 ;; ----------------------------------------------------------------------------------
 
 ;; Configure org-mode
-(use-package org
-  :functions org-babel-do-load-languages
-  :mode ((rx ".org" string-end) . org-mode)
+(leaf org
+  :mode `(,(rx ".org" string-end) . org-mode)
   :custom
-  (org-latex-listings t "Whether to use lstlistings for org latex exports")
-  :config
+  (org-latex-listings . t)
+  :defer-config
   (org-babel-do-load-languages
    'org-babel-load-languages
    '((emacs-lisp . t)
      (gnuplot . t))))
 
-(use-package org-roam
-  :demand
+(leaf org-roam
   :custom
-  (org-roam-db-location (expand-file-name "org-roam.db" data-dir))
-  (org-roam-directory "~/Documents/Notes/")
-  (org-roam-dailies-directory "Journal") ; Relative to org-roam-directory
-  (org-agenda-files '("~/Documents/Notes/Journal/"))
+  `(org-roam-db-location . ,(expand-file-name "org-roam.db" data-dir))
+  (org-roam-directory . "~/Documents/Notes/")
+  (org-roam-dailies-directory . "Journal") ; Relative to org-roam-directory
+  (org-agenda-files . '("~/Documents/Notes/Journal/"))
   :bind
-  ("C-c n f" . org-roam-node-find)
-  ("C-c n i" . org-roam-node-insert)
-  :bind-keymap
-  ("C-c n d" . org-roam-dailies-map)
-  :preface
-  (declare-function org-roam-db-autosync-mode "org-roam.el")
+  (("C-c n f" . org-roam-node-find)
+   ("C-c n i" . org-roam-node-insert))
+  :global-minor-mode org-roam-db-autosync-mode
+  :defvar org-roam-dailies-map
   :config
   (require 'org-roam-dailies)
-  (org-roam-db-autosync-mode 1))
+  (bind-key "C-c n d" 'org-roam-dailies-map))
 
 ;; Used by org-agenda to store the TODO mark
-(use-package bookmark
+(leaf bookmark
   :custom
-  (bookmark-file (expand-file-name "bookmarks" data-dir)))
+  `(bookmark-file . ,(expand-file-name "bookmarks" data-dir)))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Protobuf
 ;; ----------------------------------------------------------------------------------
 
-(use-package protobuf-mode
-  :mode (rx ".proto" string-end))
+(leaf protobuf-mode
+  :mode `(,(rx ".proto" string-end)))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Python
 ;; ----------------------------------------------------------------------------------
 
-(use-package python
-  :mode ((rx ".py" string-end) . python-mode)
+(leaf python
+  :mode `(,(rx ".py" string-end) . python-mode)
   :interpreter ("python" . python-mode)
-  :hook (python-mode . (lambda () (setq-local devdocs-current-docs '("python~3.11"))))
-  :init
-  (when (executable-find "ipython")
-    (setq python-shell-interpreter "ipython"
-          python-shell-interpreter-args "--simple-prompt -i"))
-  (when (executable-find "ipython3")
-    (setq python-shell-interpreter "ipython3"
-          python-shell-interpreter-args "--simple-prompt -i")))
+  :hook (python-mode-hook . (lambda () (setq-local devdocs-current-docs '("python~3.11"))))
+  :custom
+  (python-shell-interpreter . '(cond
+                                ((executable-find "ipython") "ipython")
+                                ((executable-find "ipython3") "ipython3")
+                                ((executable-find "python3") "python3")))
+  (python-shell-interpreter-args . "--simple-prompt -i"))
 
-(use-package cython-mode
-  :mode ((rx (or ".pyx" ".pxd" ".pxi") string-end))
-  :hook (cython-mode . (lambda () (setq-local devdocs-current-docs '("python~3.11")))))
+(leaf cython-mode
+  :mode `(,(rx (or ".pyx" ".pxd" ".pxi") string-end))
+  :hook (cython-mode-hook . (lambda () (setq-local devdocs-current-docs '("python~3.11")))))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Rust
 ;; ----------------------------------------------------------------------------------
 
-(use-package rust-mode
-  :mode ((rx ".rs" string-end) . rust-mode)
-  :hook (rust-mode . (lambda () (setq-local devdocs-current-docs '("rust")))))
-
-(use-package cargo-mode
-  :hook (rust-mode . (lambda () (setq-local devdocs-current-docs '("rust"))))
-  :mode ((rx (or (and ".rs" string-end)
-                 (and string-start "Cargo.toml" string-end)))
-         . rust-mode))
+(leaf rust-mode
+  :mode `(,(rx (or (and ".rs" string-end)
+                 (and string-start "Cargo.toml" string-end))) . rust-mode)
+  :hook (rust-mode-hook . (lambda () (setq-local devdocs-current-docs '("rust")))))
 
 ;; ----------------------------------------------------------------------------------
 ;;; SCSS
 ;; ----------------------------------------------------------------------------------
 
-(use-package scss-mode
-  :mode (rx (or ".sass" ".scss") string-end)
-  :hook (scss-mode . (lambda () (setq-local devdocs-current-docs '("css" "sass")))))
+(leaf scss-mode
+  :mode `(,(rx (or ".sass" ".scss") string-end))
+  :hook (scss-mode-hook . (lambda () (setq-local devdocs-current-docs '("css" "sass")))))
 
 ;; ----------------------------------------------------------------------------------
 ;;; *sh
 ;; ----------------------------------------------------------------------------------
 
-(use-package flymake-shellcheck
+(leaf flymake-shellcheck
   :commands flymake-shellcheck-load
-  :hook (sh-mode . flymake-shellcheck-load)
-  :hook (sh-mode . (lambda () (setq-local devdocs-current-docs '("bash")))))
+  :hook (sh-mode-hook . flymake-shellcheck-load)
+  :hook (sh-mode-hook . (lambda () (setq-local devdocs-current-docs '("bash")))))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Systemd
 ;; ----------------------------------------------------------------------------------
 
-(use-package systemd
-  :mode ((rx (or".service" ".socket" ".device" ".mount" ".automount"
+(leaf systemd
+  :mode `(,(rx (or".service" ".socket" ".device" ".mount" ".automount"
                 ".swap" ".target" ".path" ".timer" ".slice" ".scope")
              string-end)
          . systemd-mode))
@@ -262,28 +249,24 @@
 ;;; TypeScript (and other web-related DSLs)
 ;; ----------------------------------------------------------------------------------
 
-(use-package web-mode
-  :bind
-  :mode (rx (or ".pug" ".hbs" (and ".ts" (? "x"))) string-end)
-  :hook (web-mode . (lambda () (setq-local devdocs-current-docs
-                                           '("html"
-                                             "typescript"
-                                             "css"
-                                             "javascript"
-                                             "dom")))))
-
-(use-package prettier-js
-  :commands prettier-js)
+(leaf web-mode
+  :mode `(,(rx (or ".pug" ".hbs" (and ".ts" (? "x"))) string-end))
+  :hook (web-mode-hook . (lambda () (setq-local devdocs-current-docs
+                                                '("html"
+                                                  "typescript"
+                                                  "css"
+                                                  "javascript"
+                                                  "dom")))))
 
 ;; ----------------------------------------------------------------------------------
 ;;; yuck - widget markup for eww
 ;; ----------------------------------------------------------------------------------
 
-(use-package yuck-mode
-  :mode (rx ".yuck" string-end))
+(leaf yuck-mode
+  :mode `(,(rx ".yuck" string-end)))
 
-(use-package zen-mode
-  :mode (rx ".zs"))
+(leaf zen-mode
+  :mode `(,(rx ".zs")))
 
 ;; ----------------------------------------------------------------------------------
 ;; ----------------------------------------------------------------------------------
@@ -295,21 +278,21 @@
 ;;; Language servers
 ;; ----------------------------------------------------------------------------------
 
-(use-package company
-  :hook (after-init . global-company-mode)
+(leaf company
+  :hook (after-init-hook . global-company-mode)
   :custom
-  (company-idle-delay 0.1))
+  (company-idle-delay . 0.1))
 
-(use-package eldoc
+(leaf eldoc
   :bind (("C-c l d" . 'eldoc-doc-buffer))
   :custom
-    (eldoc-echo-area-prefer-doc-buffer t)
-  (eldoc-echo-area-use-multiline-p .15)
-  (eldoc-echo-area-display-truncation-message 'nil)
+  (eldoc-echo-area-prefer-doc-buffer . t)
+  (eldoc-echo-area-use-multiline-p . .15)
+  (eldoc-echo-area-display-truncation-message . 'nil)
   :config
   (global-eldoc-mode 1))
 
-(use-package xref
+(leaf xref
   :bind (("C-c l f" . xref-find-definitions-other-window)))
 
 (defun set-eldoc-compose ()
@@ -318,43 +301,44 @@
   (with-suppressed-warnings ((obsolete eldoc-documentation-strategy))
     (setq-local eldoc-documentation-strategy #'eldoc-documentation-compose)))
 
-(use-package eglot
-  :commands (eglot eglot-format eglot-managed-p eglot--major-mode eglot-alternatives)
-  :hook (((kotlin-mode web-mode rust-mode python-mode sh-mode c-mode c++-mode nix-mode json-mode) .
-          eglot-ensure)
-         (eglot-managed-mode . set-eldoc-compose))
-  :bind
-  (:map eglot-mode-map
-        ("C-c l r" . eglot-rename)
-        ("C-c l a" . eglot-code-actions)
-        ("C-c l i" . consult-eglot-symbols))
-  :init
-  (setq eglot-workspace-configuration
-        '((nixd
-           (formatting
-            (command . ["nixfmt"])))
-          (pylsp
-           (plugins
-            (pydocstyle
-             (enabled . t)
-             ;; Does not currently work:
-             ;; https://github.com/python-lsp/python-lsp-server/issues/159
-             (match . ".*"))
-            (pycodestyle
-             ;; Make compatible with black:
-             ;; https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length
-             (maxLineLength . 88)
-             ;; Only E203 is incompatible with black and enabled by
-             ;; default, but defining *any* ignore list will override
-             ;; the default ignore list, so we need to recreate the
-             ;; original.
-             ;;
-             ;; See also the small caveat under the huge table here:
-             ;; https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
-             (ignore . ["E203" "E121" "E123" "E126" "E133" "E226"
-                        "E241" "E242" "E704" "W503" "W504" "W505"]))))))
+(leaf eglot
+  :commands (eglot eglot-format eglot-managed-p)
+  :hook (((kotlin-mode-hook web-mode-hook rust-mode-hook python-mode-hook
+           sh-mode-hook c-mode-hook c++-mode-hook nix-mode-hook json-mode-hook) .
+           eglot-ensure)
+         (eglot-managed-mode-hook . set-eldoc-compose))
+  :bind (:eglot-mode-map
+         ("C-c l r" . eglot-rename)
+         ("C-c l a" . eglot-code-actions)
+         ("C-c l i" . consult-eglot-symbols))
+  :defun eglot-alternatives
+  :defvar eglot-workspace-configuration eglot-server-programs
+  :setq (eglot-workspace-configuration .
+    '((nixd
+       (formatting
+        (command . ["nixfmt"])))
+      (pylsp
+       (plugins
+        (pydocstyle
+         (enabled . t)
+         ;; Does not currently work:
+         ;; https://github.com/python-lsp/python-lsp-server/issues/159
+         (match . ".*"))
+        (pycodestyle
+         ;; Make compatible with black:
+         ;; https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length
+         (maxLineLength . 88)
+         ;; Only E203 is incompatible with black and enabled by
+         ;; default, but defining *any* ignore list will override
+         ;; the default ignore list, so we need to recreate the
+         ;; original.
+         ;;
+         ;; See also the small caveat under the huge table here:
+         ;; https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
+         (ignore . ["E203" "E121" "E123" "E126" "E133" "E226"
+                    "E241" "E242" "E704" "W503" "W504" "W505"]))))))
 
-  :config
+  :defer-config
   (add-to-list 'eglot-server-programs
                '(rust-mode . ("rust-analyzer"
                               :initializationOptions
@@ -369,30 +353,30 @@
   (add-to-list 'eglot-server-programs
                '(nix-mode . ("nixd"))))
 
-(use-package eglot-x
+(leaf eglot-x
   :after eglot
-  :commands eglot-x-setup
-  :demand t
+  :require t
+  :defun eglot-x-setup
   :config
   (eglot-x-setup))
 
-(use-package flymake
-  :hook (prog-mode . flymake-mode)
-  :bind (:map flymake-mode-map
+(leaf flymake
+  :hook (prog-mode-hook . flymake-mode)
+  :bind (:flymake-mode-map
               ("C-c l e" . flymake-show-buffer-diagnostics)))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Autoformatting
 ;; ----------------------------------------------------------------------------------
 
-(use-package reformatter
+(leaf reformatter
   :commands (biome-format-region
              biome-format-buffer
              clang-format-region
              clang-format-buffer
              latexindent-region
              latexindent-buffer)
-  :config
+  :defer-config
   ;; Work around `make-variable-buffer-local' being called at a
   ;; non-top-level.
   ;;

--- a/home-config/dotfiles/emacs.d/config/sane-defaults.el
+++ b/home-config/dotfiles/emacs.d/config/sane-defaults.el
@@ -25,8 +25,7 @@
 ;;; Code:
 
 (eval-and-compile
-  (require 'use-package)
-  (defvar back-dir))
+  (require 'leaf))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Remove pointless UI components
@@ -56,6 +55,7 @@
   "Suspend-frame, but don't do it to my graphical windows.
 
    ORIG is the original function, ARGS the arguments passed to the invocation."
+  (interactive)
   (when (not (display-graphic-p))
     (suspend-frame)))
 
@@ -83,8 +83,8 @@
 ;;; Fix auto-completion completing everything lowercase
 ;; ----------------------------------------------------------------------------------
 
-(use-package dabbrev
+(leaf dabbrev
   :custom
-  (dabbrev-case-fold-search nil))
+  (dabbrev-case-fold-search . nil))
 
 ;;; sane-defaults.el ends here

--- a/home-config/dotfiles/emacs.d/config/theme.el
+++ b/home-config/dotfiles/emacs.d/config/theme.el
@@ -25,30 +25,31 @@
 ;;; Code:
 
 (eval-and-compile
-  (require 'use-package))
+  (require 'leaf))
 
-(use-package gotham-theme
-  :init
-  (setq gotham-tty-256-colors t)
+(leaf gotham-theme
+  :defvar gotham-tty-256-colors
+  :custom
+  (gotham-tty-256-colors . t)
+  (gotham-color-alist .
+    `((base0   "#0f0f0f" ,(if gotham-tty-256-colors "color-232" "black"))
+      (base1   "#11151c" ,(if gotham-tty-256-colors "color-233" "brightblack"))
+      (base2   "#091f2e" ,(if gotham-tty-256-colors "color-17"  "brightgreen"))
+      (base3   "#0a3749" ,(if gotham-tty-256-colors "color-18"  "brightblue"))
+      (base4   "#245361" ,(if gotham-tty-256-colors "color-24"  "brightyellow"))
+      (base5   "#268bd2" ,(if gotham-tty-256-colors "color-81"  "brightcyan"))
+      (base6   "#99d1ce" ,(if gotham-tty-256-colors "color-122" "white"))
+      (base7   "#d3ebe9" ,(if gotham-tty-256-colors "color-194" "brightwhite"))
 
-  (setq gotham-color-alist
-        `((base0   "#0f0f0f" ,(if gotham-tty-256-colors "color-232" "black"))
-          (base1   "#11151c" ,(if gotham-tty-256-colors "color-233" "brightblack"))
-          (base2   "#091f2e" ,(if gotham-tty-256-colors "color-17"  "brightgreen"))
-          (base3   "#0a3749" ,(if gotham-tty-256-colors "color-18"  "brightblue"))
-          (base4   "#245361" ,(if gotham-tty-256-colors "color-24"  "brightyellow"))
-          (base5   "#268bd2" ,(if gotham-tty-256-colors "color-81"  "brightcyan"))
-          (base6   "#99d1ce" ,(if gotham-tty-256-colors "color-122" "white"))
-          (base7   "#d3ebe9" ,(if gotham-tty-256-colors "color-194" "brightwhite"))
-
-          (red     "#dc322f" ,(if gotham-tty-256-colors "color-124" "red"))
-          (orange  "#d26937" ,(if gotham-tty-256-colors "color-166" "brightred"))
-          (yellow  "#b58900" ,(if gotham-tty-256-colors "color-214" "yellow"))
-          (magenta "#707880" ,(if gotham-tty-256-colors "color-67"  "brightmagenta"))
-          (violet  "#4e5166" ,(if gotham-tty-256-colors "color-60"  "magenta"))
-          (blue    "#195466" ,(if gotham-tty-256-colors "color-24"  "blue"))
-          (cyan    "#599cab" ,(if gotham-tty-256-colors "color-44"  "cyan"))
-          (green   "#2aa889" ,(if gotham-tty-256-colors "color-78"  "green"))))
+      (red     "#dc322f" ,(if gotham-tty-256-colors "color-124" "red"))
+      (orange  "#d26937" ,(if gotham-tty-256-colors "color-166" "brightred"))
+      (yellow  "#b58900" ,(if gotham-tty-256-colors "color-214" "yellow"))
+      (magenta "#707880" ,(if gotham-tty-256-colors "color-67"  "brightmagenta"))
+      (violet  "#4e5166" ,(if gotham-tty-256-colors "color-60"  "magenta"))
+      (blue    "#195466" ,(if gotham-tty-256-colors "color-24"  "blue"))
+      (cyan    "#599cab" ,(if gotham-tty-256-colors "color-44"  "cyan"))
+      (green   "#2aa889" ,(if gotham-tty-256-colors "color-78"  "green"))))
+  :config
   (load-theme 'gotham t))
 
 ;;; theme.el ends here

--- a/home-config/dotfiles/emacs.d/config/ui.el
+++ b/home-config/dotfiles/emacs.d/config/ui.el
@@ -25,7 +25,7 @@
 ;;; Code:
 
 (eval-and-compile
-  (require 'use-package))
+  (require 'leaf))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Custom navigation and text editing keybinds
@@ -65,8 +65,7 @@
 ;;; Other various useful keybindings
 ;; ----------------------------------------------------------------------------------
 
-(use-package crux
-  :demand
+(leaf crux
   :bind
   ("C-c o" . crux-open-with)
   ([remap kill-line] . crux-smart-kill-line)
@@ -76,21 +75,17 @@
   ("C-c C" . crux-copy-file-preserve-attributes)
   ("C-c R" . crux-rename-file-and-buffer)
   ([remap delete-indentation] . crux-top-join-line)
-  :preface
-  (declare-function crux-reopen-as-root-mode "crux.el")
-  :config
-  (crux-with-region-or-buffer comment-or-uncomment-region)
-  (crux-reopen-as-root-mode))
+  :global-minor-mode crux-reopen-as-root-mode)
 
-(use-package consult
-  :functions (consult-register-window consult-xref consult-register-format)
+(leaf consult
+  :defun (consult-register-window consult-xref consult-register-format)
   :custom
-  (register-preview-delay 0.5)
-  (register-preview-function #'consult-register-format)
-  (xref-show-xrefs-function #'consult-xref)
-  (xref-show-definitions-function #'consult-xref)
+  (register-preview-delay . 0.5)
+  (register-preview-function . #'consult-register-format)
+  (xref-show-xrefs-function . #'consult-xref)
+  (xref-show-definitions-function . #'consult-xref)
 
-  (consult-buffer-filter
+  (consult-buffer-filter .
    `(,(rx string-start " ")
      ,(rx string-start "*Completions*" string-end)
      ,(rx string-start "*Flymake log*" string-end)
@@ -123,31 +118,27 @@
          ("M-s r" . consult-ripgrep)
          ("M-s f" . consult-find)
          ("M-s m" . consult-man)
-         ("M-s e" . consult-isearch-history)
+         ("M-s h" . consult-isearch-history)
          ;; Consider keep-lines, focus-lines
          )
-  :config
-  (advice-add #'register-preview :override #'consult-register-window))
+  :advice (:override register-preview consult-register-window))
 
-(use-package consult-eglot
-  :commands consult-eglot-symbols)
+(leaf consult-eglot
+  :after eglot
+  :bind ("M-s e" . consult-eglot-symbols))
 
-(use-package consult-org-roam
-  :demand
+(leaf consult-org-roam
   :after org-roam
   :bind
   ("C-c n b" . consult-org-roam-backlinks)
   ("C-c n l" . consult-org-roam-forward-links)
   ("C-c n s" . consult-org-roam-search)
   :custom
-  (consult-org-roam-grep-func #'consult-ripgrep)
-  (consult-org-roam-buffer-after-buffers t)
-  :preface
-  (declare-function consult-org-roam-mode "consult-org-roam.el")
-  :config
-  (consult-org-roam-mode 1))
+  (consult-org-roam-grep-func . #'consult-ripgrep)
+  (consult-org-roam-buffer-after-buffers . t)
+  :global-minor-mode consult-org-roam-mode)
 
-(use-package consult-project-extra
+(leaf consult-project-extra
   :bind
   ([remap project-find-file] . consult-project-extra-find)
   ("C-x p 4 f" . consult-project-extra-find-other-window))
@@ -157,35 +148,30 @@
 ;; ----------------------------------------------------------------------------------
 
 ;; Make pairs of parens highlight
-(use-package paren
-  :config
-  (show-paren-mode 1))
+(leaf paren
+  :global-minor-mode show-paren-mode)
 
 ;; Highlight TODO notes
-(use-package fic-mode
-  :hook prog-mode
+(leaf fic-mode
+  :hook prog-mode-hook
   :custom-face
-  (fic-face ((t (:foreground "darkred" :weight bold))))
-  (fic-author-face ((t (:foreground "orangered" :underline t)))))
+  (fic-face . '((t (:foreground "darkred" :weight bold))))
+  (fic-author-face . '((t (:foreground "orangered" :underline t)))))
 
 ;; Colorful color names :3
-(use-package rainbow-mode
-  :hook (prog-mode text-mode))
+(leaf rainbow-mode
+  :hook (prog-mode-hook text-mode-hook))
 
 ;; Highlight the current line
-(use-package hl-line
-  :config
-  (global-hl-line-mode 1))
+(leaf hl-line
+  :global-minor-mode global-hl-line-mode)
 
 ;; Show whitespace when it isn't correct
-(use-package whitespace
-  :demand
-  :commands global-whitespace-mode
+(leaf whitespace
   :custom
-  (whitespace-style '(face trailing indentation space-after-tab
+  (whitespace-style . '(face trailing indentation space-after-tab
                            space-before-tab))
-  (whitespace-global-modes '(not erc-mode))
-  :config
-  (global-whitespace-mode))
+  (whitespace-global-modes . '(not erc-mode))
+  :global-minor-mode global-whitespace-mode)
 
 ;;; ui.el ends here

--- a/home-config/dotfiles/emacs.d/init.el
+++ b/home-config/dotfiles/emacs.d/init.el
@@ -31,9 +31,6 @@
 ;; ----------------------------------------------------------------------------------
 
 
-(defvar config-dir (expand-file-name
-                    "config"
-                    (file-name-directory load-file-name)))
 (defvar data-dir (expand-file-name
                   "emacs"
                   (or (getenv "XDG_DATA_HOME") "~/.local/share/")))
@@ -41,8 +38,8 @@
                   "emacs/backups"
                   (or (getenv "XDG_DATA_HOME") "~/.local/share/")))
 (defvar share-dir (expand-file-name
-                   "share"
-                   (file-name-directory load-file-name)))
+                   "emacs/share"
+                   (or (getenv "XDG_CONFIG_HOME") "~/.config")))
 (defvar cache-dir (expand-file-name
                    "emacs"
                    (or (getenv "XDG_CACHE_HOME") "~/.cache")))
@@ -64,39 +61,29 @@
 (setq package-user-dir (expand-file-name "elpa" data-dir))
 (setq package-gnupghome-dir (expand-file-name "gnupg" package-user-dir))
 
-;; Setup use-package
-;; bind-key is a dependency...
-(require 'bind-key)
-(require 'use-package)
+(require 'leaf)
 
 ;; Make sure emacs doesn't try to randomly fetch packages itself; nix is in charge of
 ;; that
 (setq package-enable-at-startup nil)
-(setq use-package-always-ensure nil)
-(setq use-package-ensure-function 'ignore)
-
-;; Avoid all kinds of byte compilation warnings - see
-;; https://github.com/jwiegley/use-package/issues/590
-(eval-when-compile
-  (setq use-package-expand-minimally byte-compile-current-file))
 
 ;; ----------------------------------------------------------------------------------
 ;;; Set up improved garbage collection for better startup and runtime performance.
 ;; ----------------------------------------------------------------------------------
 
-(use-package gcmh
-  :config
-  (gcmh-mode 1))
+(leaf gcmh
+  :global-minor-mode t)
 
 ;; ----------------------------------------------------------------------------------
 ;;; Load other configuration files
 ;; ----------------------------------------------------------------------------------
 
 ;; Load everything in the config directory
-(when (file-exists-p config-dir)
-  (mapc (lambda (file)
-          (load (file-name-sans-extension file) nil nil nil t))
-        (directory-files config-dir t "^[^#\.].*\\.el$")))
+(let ((config-dir (expand-file-name "config" (file-name-directory load-file-name))))
+  (when (file-exists-p config-dir)
+    (mapc (lambda (file)
+            (load (file-name-sans-extension file) nil nil nil t))
+          (directory-files config-dir t "^[^#\.].*\\.el$"))))
 
 ;; Finally load `custom.el'' for any declarative settings; there *should* be none, but
 ;; occasionally I need something a bit less rigid than my nix config for a little while.

--- a/pkgs/_sources/generated.json
+++ b/pkgs/_sources/generated.json
@@ -56,6 +56,26 @@
         },
         "version": "2.1.22-31"
     },
+    "eglot-x": {
+        "cargoLocks": null,
+        "date": "2024-04-27",
+        "extract": null,
+        "name": "eglot-x",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "nemethf",
+            "repo": "eglot-x",
+            "rev": "cc6a198945211bd20a6e1e2f448fecdc18ca5c88",
+            "sha256": "sha256-BKXJvODdqqNjO4XyH/HH6CRPRVhmuJt67cRJWQ3WKAQ=",
+            "type": "github"
+        },
+        "version": "cc6a198945211bd20a6e1e2f448fecdc18ca5c88"
+    },
     "firefox-ui-fix": {
         "cargoLocks": null,
         "date": null,

--- a/pkgs/_sources/generated.nix
+++ b/pkgs/_sources/generated.nix
@@ -31,6 +31,18 @@
       sha256 = "sha256-2O0TjRhuwLd+QPUxV9tHeuWYtGoRnBa6icU7DMmxWyI=";
     };
   };
+  eglot-x = {
+    pname = "eglot-x";
+    version = "cc6a198945211bd20a6e1e2f448fecdc18ca5c88";
+    src = fetchFromGitHub {
+      owner = "nemethf";
+      repo = "eglot-x";
+      rev = "cc6a198945211bd20a6e1e2f448fecdc18ca5c88";
+      fetchSubmodules = false;
+      sha256 = "sha256-BKXJvODdqqNjO4XyH/HH6CRPRVhmuJt67cRJWQ3WKAQ=";
+    };
+    date = "2024-04-27";
+  };
   firefox-ui-fix = {
     pname = "firefox-ui-fix";
     version = "v8.6.1";

--- a/pkgs/applications/emacs/default.nix
+++ b/pkgs/applications/emacs/default.nix
@@ -26,7 +26,12 @@ let
   required-packages = builtins.fromJSON (builtins.readFile package-list) ++ [ "leaf" ];
 
   custom-emacs = emacsPkgs.emacs.pkgs.withPackages (
-    epkgs: map (package: builtins.getAttr package epkgs) required-packages
+    epkgs: (map (package: builtins.getAttr package epkgs) required-packages) ++ [
+      (epkgs.treesit-grammars.with-grammars (grammars: with grammars; [
+        tree-sitter-typescript
+        tree-sitter-tsx
+      ]))
+    ]
   );
 in
 custom-emacs

--- a/pkgs/applications/emacs/default.nix
+++ b/pkgs/applications/emacs/default.nix
@@ -20,9 +20,9 @@ let
     '';
   };
 
-  overrides = _self: _super: { };
+  overrides = self: _super: { eglot-x = self.callPackage ./eglot-x.nix { inherit sources; }; };
 
-  emacsPkgs = (emacsPackagesFor emacsPlatform).overrideScope' overrides;
+  emacsPkgs = (emacsPackagesFor emacsPlatform).overrideScope overrides;
 
   # Compute the list of use-package-d packages.
   package-list = runCommandLocal "package-list" { buildInputs = [ emacsPkgs.emacs ]; } ''

--- a/pkgs/applications/emacs/default.nix
+++ b/pkgs/applications/emacs/default.nix
@@ -7,6 +7,7 @@
   emacsMacport,
   emacs29,
   runCommandLocal,
+  git,
 }:
 let
   emacsPlatform = if hostPlatform.isDarwin then emacsMacport else emacs29;
@@ -39,14 +40,22 @@ let
     epkgs: map (package: builtins.getAttr package epkgs) required-packages
   );
 
-  compiled-dotfiles = runCommandLocal "compiled-init" { buildInputs = [ custom-emacs ]; } ''
-    cp -r '${self}/home-config/dotfiles/emacs.d/' "$out"
-    chmod -R u+w "$out"
+  compiled-dotfiles =
+    runCommandLocal "compiled-init"
+      {
+        buildInputs = [
+          git
+          custom-emacs
+        ];
+      }
+      ''
+        cp -r '${self}/home-config/dotfiles/emacs.d/' "$out"
+        chmod -R u+w "$out"
 
-    HOME=/tmp emacs --batch \
-        --eval "(setq byte-compile-error-on-warn t)" \
-        -f batch-byte-compile \
-        "$out/init.el" "$out/config/"*
-  '';
+        HOME=/tmp emacs --batch \
+            --eval "(setq byte-compile-error-on-warn t)" \
+            -f batch-byte-compile \
+            "$out/init.el" "$out/config/"*
+      '';
 in
 custom-emacs // (custom-emacs.passthru // { dotfiles = compiled-dotfiles; })

--- a/pkgs/applications/emacs/default.nix
+++ b/pkgs/applications/emacs/default.nix
@@ -27,14 +27,13 @@ let
   # Compute the list of use-package-d packages.
   package-list = runCommandLocal "package-list" { buildInputs = [ emacsPkgs.emacs ]; } ''
     HOME=/tmp SCANNING_PACKAGES=true emacs --batch --quick \
-          -L ${emacsPkgs.use-package}/share/emacs/site-lisp/elpa/use-package-* \
           -L ${emacsPkgs.bind-key}/share/emacs/site-lisp/elpa/bind-key-* \
           -l ${use-package-list}/use-package-list.el \
           --eval "(use-package-list \"${self}/home-config/dotfiles/emacs.d/init.el\")" \
           > $out
   '';
 
-  required-packages = builtins.fromJSON (builtins.readFile package-list) ++ [ "use-package" ];
+  required-packages = builtins.fromJSON (builtins.readFile package-list);
 
   custom-emacs = emacsPkgs.emacs.pkgs.withPackages (
     epkgs: map (package: builtins.getAttr package epkgs) required-packages

--- a/pkgs/applications/emacs/default.nix
+++ b/pkgs/applications/emacs/default.nix
@@ -6,7 +6,6 @@
   emacsMacport,
   emacs29,
   runCommandLocal,
-  git,
 }:
 let
   emacsPlatform = if hostPlatform.isDarwin then emacsMacport else emacs29;
@@ -29,31 +28,5 @@ let
   custom-emacs = emacsPkgs.emacs.pkgs.withPackages (
     epkgs: map (package: builtins.getAttr package epkgs) required-packages
   );
-
-  compiled-dotfiles =
-    runCommandLocal "compiled-init"
-      {
-        buildInputs = [
-          git
-          custom-emacs
-        ];
-      }
-      ''
-        cp -r '${self}/home-config/dotfiles/emacs.d/' "$out"
-        chmod -R u+w "$out"
-
-        HOME=/tmp emacs --batch \
-            -L "$out" \
-            --eval "(setq byte-compile-error-on-warn t)" \
-            -f batch-byte-compile \
-            "$out"/{init.el,config/*} 2>&1 | tee compilation-output
-
-        if grep -q '^Error' compilation-output; then
-            echo 'Byte compilation errors present; exiting'
-            exit 1
-        else
-            echo 'Byte compilation successful'
-        fi
-      '';
 in
-custom-emacs // (custom-emacs.passthru // { dotfiles = compiled-dotfiles; })
+custom-emacs

--- a/pkgs/applications/emacs/eglot-x.nix
+++ b/pkgs/applications/emacs/eglot-x.nix
@@ -1,0 +1,4 @@
+{ sources, trivialBuild }:
+trivialBuild {
+  inherit (sources.eglot-x) pname version src;
+}

--- a/pkgs/applications/emacs/leaf-package-list.el
+++ b/pkgs/applications/emacs/leaf-package-list.el
@@ -1,0 +1,49 @@
+;;; leaf-package-list.el --- List packages required by leaf      -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024  Tristan Daniël Maat
+
+;; Author: Tristan Daniël Maat <tm@tlater.net>
+;; Keywords:
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+
+(require 'json)
+(require 'package)
+
+(defun leaf-package-list (script)
+  "List packages configured with leaf in SCRIPT."
+
+  (defvar leaf-package-list-running-p t)
+  (defvar leaf-package-list--packages nil)
+
+  (defmacro leaf (package &rest args)
+    (when (and (not (package-built-in-p package))
+               (if (plist-member args :ensure)
+                   (not (eq (plist-get args :ensure) nil))
+                 t))
+      `(add-to-list 'leaf-package-list--packages (symbol-name (quote ,package)))))
+  (load script nil nil t)
+  (princ (if leaf-package-list--packages
+             (json-encode leaf-package-list--packages)
+           "[]"))
+  leaf-package-list--packages)
+
+(provide 'leaf)
+;;; leaf-package-list.el ends here

--- a/pkgs/nvfetcher.toml
+++ b/pkgs/nvfetcher.toml
@@ -10,6 +10,10 @@ fetch.github = "Rikorose/DeepFilterNet"
 src.cmd = "./get-drivestrike-version.sh"
 fetch.url = "https://app.drivestrike.com/static/yum/drivestrike.rpm"
 
+[eglot-x]
+src.git = "https://github.com/nemethf/eglot-x"
+fetch.github = "nemethf/eglot-x"
+
 [firefox-ui-fix]
 src.github = "black7375/Firefox-UI-Fix"
 fetch.github = "black7375/Firefox-UI-Fix"


### PR DESCRIPTION
This switches from use-package to [`leaf`](https://github.com/conao3/leaf.el) to fix byte compilation issues, and solves a few small issues with the current build process.

Also fixes biome/typescript-language-server not working while in web-mode, and adds eglot-x instead of hand-written mini functions to provide its functionality.

~~First pass on leaf is done, but I need to sit down and fix all the resulting bugs (e.g. smartparens not working). The current fix to tsx isn't great either, I should just add [`tsx-mode`](https://github.com/orzechowskid/tsx-mode.el) directly.~~

~~Leaf conversion is now properly done; only problem is that byte compilation seems to resolve my `defvar`s to static values, which then end up with the compilation defaults, i.e. `/tmp/.local/recentf` and consorts.~~

~~Leaf conversion *almost* done, only thing left is to figure out how to fix `org-roam-dailies`.~~

Leaf conversion done!