### PR TITLE
feat(nvidia): Update driver settings

### DIFF
--- a/nixos-config/hosts/yui/nvidia/default.nix
+++ b/nixos-config/hosts/yui/nvidia/default.nix
@@ -48,16 +48,12 @@
         # nvidia assume that by default your CPU does not support PAT,
         # but this is effectively never the case in 2023
         "NVreg_UsePageAttributeTable=1"
-        # This may be a noop, but it's somewhat uncertain
-        "NVreg_EnablePCIeGen3=1"
         # This is sometimes needed for ddc/ci support, see
         # https://www.ddcutil.com/nvidia/
         #
         # Current monitor does not support it, but this is useful for
         # the future
         "NVreg_RegistryDwords=RMUseSwI2c=0x01;RMI2cSpeed=100"
-        # When (if!) I get another nvidia GPU, check for resizeable bar
-        # settings
       ];
   };
 


### PR DESCRIPTION
New GPU supports PCIe gen 4, and resizeable BAR is set by default as long as the motherboard supports it.