### PR TITLE
bump(nvidia): Update nvidia driver to 565.57.01

### DIFF
--- a/nixos-config/hosts/yui/nvidia/default.nix
+++ b/nixos-config/hosts/yui/nvidia/default.nix
@@ -10,12 +10,12 @@
 
   hardware.nvidia = {
     package = config.boot.kernelPackages.nvidiaPackages.mkDriver {
-      version = "560.35.03";
-      sha256_64bit = "sha256-8pMskvrdQ8WyNBvkU/xPc/CtcYXCa7ekP73oGuKfH+M=";
-      sha256_aarch64 = "sha256-s8ZAVKvRNXpjxRYqM3E5oss5FdqW+tv1qQC2pDjfG+s=";
-      openSha256 = "sha256-/32Zf0dKrofTmPZ3Ratw4vDM7B+OgpC4p7s+RHUjCrg=";
-      settingsSha256 = "sha256-kQsvDgnxis9ANFmwIwB7HX5MkIAcpEEAHc8IBOLdXvk=";
-      persistencedSha256 = "sha256-E2J2wYYyRu7Kc3MMZz/8ZIemcZg68rkzvqEwFAL3fFs=";
+      version = "565.57.01";
+      sha256_64bit = "sha256-buvpTlheOF6IBPWnQVLfQUiHv4GcwhvZW3Ks0PsYLHo=";
+      sha256_aarch64 = lib.fakeHash;
+      openSha256 = "sha256-/tM3n9huz1MTE6KKtTCBglBMBGGL/GOHi5ZSUag4zXA=";
+      settingsSha256 = lib.fakeHash;
+      persistencedSha256 = lib.fakeHash;
     };
 
     # The nvidia-settings build is currently broken due to a missing


### PR DESCRIPTION
Important because
https://www.gamingonlinux.com/2024/10/nvidia-detail-new-gpu-driver-vulnerabilities-in-their-october-2024-security-bulletin/