### PR TITLE
fix(emacs): Switch to using `melpaBuild` to fix package loading

### DIFF
--- a/pkgs/applications/emacs/eglot-x.nix
+++ b/pkgs/applications/emacs/eglot-x.nix
@@ -1,1 +1,8 @@
-{ sources, trivialBuild }: trivialBuild { inherit (sources.eglot-x) pname version src; }
+{ sources, melpaBuild }:
+melpaBuild {
+  inherit (sources.eglot-x) pname src;
+  # Build a MELPA unstable version string - this is the date with no
+  # separators followed by the hour/minute of the commit. We don't
+  # have the latter so we set it to 0.
+  version = builtins.replaceStrings [ "-" ] [ "" ] sources.eglot-x.date + ".0000";
+}


### PR DESCRIPTION
Apparently `trivialBuild` doesn't place stuff in the right directory.