### PR TITLE
feat(bluetooth): Allow SBC codec

### DIFF
--- a/nixos-config/default.nix
+++ b/nixos-config/default.nix
@@ -205,6 +205,7 @@
               "opus_05_duplex"
               "aac"
               "sbc_xq"
+              "sbc"
             ];
 
             "bluez5.hfphsp-backend" = "none";

--- a/pkgs/applications/emacs/eglot-x.nix
+++ b/pkgs/applications/emacs/eglot-x.nix
@@ -1,1 +1,8 @@
-{ sources, trivialBuild }: trivialBuild { inherit (sources.eglot-x) pname version src; }
+{ sources, melpaBuild }:
+melpaBuild {
+  inherit (sources.eglot-x) pname src;
+  # Build a MELPA unstable version string - this is the date with no
+  # separators followed by the hour/minute of the commit. We don't
+  # have the latter so we set it to 0.
+  version = builtins.replaceStrings [ "-" ] [ "" ] sources.eglot-x.date + ".0000";
+}


### PR DESCRIPTION
Apparently the JBL Go 3 requires having SBC *available* to connect,
though it does support SBC-XQ afterwards.