### PR TITLE
feat(emacs): Switch nix language server to `nil`

### DIFF
--- a/home-config/config/applications/tty/emacs.nix
+++ b/home-config/config/applications/tty/emacs.nix
@@ -31,7 +31,7 @@ in
 
     # Language servers and linters for super generic stuff
     biome # json/web stuff
-    nixd # nix
+    nil # nix
     ruff # python
     # *sh
     bash-language-server

--- a/home-config/dotfiles/emacs.d/config/programming-languages.el
+++ b/home-config/dotfiles/emacs.d/config/programming-languages.el
@@ -187,7 +187,7 @@
   (nix-mode-hook . eglot-ensure)
   :defer-config
   (add-to-list 'eglot-server-programs
-               '(nix-mode . ("nixd"))))
+               '(nix-mode . ("nil"))))
 
 ;; ----------------------------------------------------------------------------------
 ;;; org
@@ -422,9 +422,10 @@
   :defun eglot-alternatives
   :defvar eglot-workspace-configuration
   :setq-default (eglot-workspace-configuration .
-    '((nixd
+    '((nil
        (formatting
-        (command . ["nixfmt" "--strict"])))
+        (command . ["nixfmt" "--strict"]))
+       (nix (flake (autoEvalInputs . :json-false))))
       (pylsp
        (plugins
         (pydocstyle


### PR DESCRIPTION
I don't remember why I switched to `nixd`, but `nil`'s code actions are much better and it seems to otherwise have feature parity - at least without doing a lot of project-specific configuration.