### PR TITLE
fix(easyNvidia): Enable hardware video decoding on FF 137+

### DIFF
--- a/nixos-modules/nvidia/vaapi.nix
+++ b/nixos-modules/nvidia/vaapi.nix
@@ -6,6 +6,7 @@
 }:
 let
   cfg = config.easyNvidia.vaapi;
+  ffVersion = config.programs.firefox.package.version;
 in
 {
   options.easyNvidia.vaapi = with lib.types; {
@@ -81,8 +82,9 @@ in
     };
 
     programs.firefox.preferences = lib.mkIf cfg.firefox.enable {
-      "media.ffmpeg.vaapi.enabled" = true;
-      "media.rdd-ffmpeg.enabled" = true;
+      "media.ffmpeg.vaapi.enabled" = lib.versionOlder ffVersion "137.0.0";
+      "media.hardware-video-decoding.force-enabled" = lib.versionAtLeast ffVersion "137.0.0";
+      "media.rdd-ffmpeg.enabled" = lib.versionOlder ffVersion "97.0.0";
       "media.av1.enabled" = cfg.firefox.av1Support;
       "gfx.x11-egl.force-enabled" = true;
       "widget.dmabuf.force-enabled" = true;


### PR DESCRIPTION
This is required since Firefox version 137.