### PR TITLE
fix(nushell): Fix carapace completions for nushell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -483,6 +483,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1754498491,
+        "narHash": "sha256-erbiH2agUTD0Z30xcVSFcDHzkRvkRXOQ3lb887bcVrs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c2ae88e026f9525daf89587f3cbee584b92b6134",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1754214453,
@@ -593,6 +609,7 @@
         "nixos-anywhere": "nixos-anywhere",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "nurpkgs": "nurpkgs_2",
         "sops-nix": "sops-nix",
         "stylix": "stylix"

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
     sops-nix = {

--- a/home-config/config/shell/nushell.nix
+++ b/home-config/config/shell/nushell.nix
@@ -1,4 +1,9 @@
-{ config, ... }:
+{
+  config,
+  pkgs,
+  flake-inputs,
+  ...
+}:
 {
   home.shell.enableNushellIntegration = true;
 
@@ -7,5 +12,9 @@
     configFile.source = "${config._dotfiles}/nushell/config.nu";
   };
 
-  programs.carapace.enable = true;
+  programs.carapace = {
+    enable = true;
+    # Needed because of https://github.com/nix-community/home-manager/issues/7517
+    package = flake-inputs.nixpkgs-unstable.legacyPackages.${pkgs.system}.carapace;
+  };
 }


### PR DESCRIPTION
Apparently a new version of nushell became incompatible with carapace, which then fixed this in a backwards-incompatible way. As a result, completions broke.

This now uses the unstable carapace package, which correctly supports both old and new nushell versions.