### PR TITLE
fix(nvfetcher): Fix nvidia download url

### DIFF
--- a/pkgs/nvfetcher.toml
+++ b/pkgs/nvfetcher.toml
@@ -35,7 +35,7 @@ fetch.github = "taquangtrung/emacs-kdl-mode"
 [nvidia]
 src.webpage = "https://www.nvidia.com/en-us/drivers/unix/"
 src.regex = "Latest Production Branch Version:</span> <a href=.*?> (.*?)</a>"
-fetch.url = "https://download.nvidia.com/XFree86/Linux-x86_64/$ver/NVIDIA-Linux-x86_64-$ver.run"
+fetch.url = "https://us.download.nvidia.com/XFree86/Linux-x86_64/$ver/NVIDIA-Linux-x86_64-$ver.run"
 
 [nvidia-open]
 src.webpage = "https://www.nvidia.com/en-us/drivers/unix/"


### PR DESCRIPTION
The other mirror does also work long-term, but apparently does not always have the driver available on release.