### PR TITLE
fix(unbound): Start before NetworkManager

### DIFF
--- a/nixos-config/hosts/yui/wireguard-dispatchers.nu
+++ b/nixos-config/hosts/yui/wireguard-dispatchers.nu
@@ -1,6 +1,15 @@
 use std/log
 
-def main [interface: string, action: string] {
+def main [interface_arg: string, action_arg?: string] {
+  let action = $action_arg | default $interface_arg
+  let interface = match $interface_arg {
+    none => null,
+    _ if $action_arg == null => null,
+    $other => $other
+  }
+
+  log debug $"($interface) ($action)"
+
   match $interface {
     "wgt-pvpn" => {
       match $action {

--- a/nixos-config/networking/default.nix
+++ b/nixos-config/networking/default.nix
@@ -1,3 +1,4 @@
+{ lib, ... }:
 {
   users.users.tlater.extraGroups = [ "networking" ];
 
@@ -46,4 +47,9 @@
 
     localControlSocketPath = "/run/unbound/unbound.ctl";
   };
+
+  # Ensure unbound is available for DNS settings by the time
+  # connections might set such
+  systemd.services.unbound.after = lib.mkForce [ ];
+  systemd.services.unbound.before = [ "NetworkManager.service" ];
 }


### PR DESCRIPTION
This allows setting DNS settings with NetworkManager dispatchers; unbound doesn't need the network to be up for anything (except actually resolving DNS, of course, but that won't be necessary if there's no networking anyway).