### PR TITLE
Restore wireless bonds

### DIFF
--- a/nixos-config/hosts/rin/default.nix
+++ b/nixos-config/hosts/rin/default.nix
@@ -40,27 +40,29 @@
 
   users.users.tlater.extraGroups = [ "docker" ];
 
-  # Incompatible with docker
-  networking.nftables.enable = lib.mkForce false;
+  networking = {
+    # Incompatible with docker
+    nftables.enable = lib.mkForce false;
 
-  # Allow docker containers to communicate
-  networking.firewall.extraCommands =
-    let
-      # Either get the docker daemon setting *or* the default value
-      dockerAddressPools =
-        config.virtualisation.docker.daemon.settings.default-address-pools or [
-          {
-            base = "172.30.0.0/16";
-            size = 24;
-          }
-          {
-            base = "172.31.0.0/16";
-            size = 24;
-          }
-        ];
-      addresses = lib.concatMapStringsSep "," (pool: pool.base) dockerAddressPools;
-    in
-    ''
-      iptables -A INPUT -s ${addresses} -d ${addresses},172.17.0.1 -j ACCEPT
-    '';
+    # Allow docker containers to communicate
+    firewall.extraCommands =
+      let
+        # Either get the docker daemon setting *or* the default value
+        dockerAddressPools =
+          config.virtualisation.docker.daemon.settings.default-address-pools or [
+            {
+              base = "172.30.0.0/16";
+              size = 24;
+            }
+            {
+              base = "172.31.0.0/16";
+              size = 24;
+            }
+          ];
+        addresses = lib.concatMapStringsSep "," (pool: pool.base) dockerAddressPools;
+      in
+      ''
+        iptables -A INPUT -s ${addresses} -d ${addresses},172.17.0.1 -j ACCEPT
+      '';
+  };
 }

--- a/nixos-config/networking/personal.nix
+++ b/nixos-config/networking/personal.nix
@@ -1,4 +1,14 @@
 {
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.networking.networkmanager;
+  ini = pkgs.formats.ini { };
+in
+{
   networking.networkmanager.ensureProfiles.profiles = {
     bond = {
       connection = {
@@ -29,5 +39,75 @@
       controller = "bond0";
       port-type = "bond";
     };
+
+    lala = {
+      connection = {
+        id = "lala";
+        type = "wifi";
+
+        controller = "bond0";
+        port-type = "bond";
+      };
+
+      wifi = {
+        mode = "infrastructure";
+        ssid = "lala";
+      };
+
+      wifi-security = {
+        key-mgmt = "sae";
+        psk = "%psk-lala%";
+      };
+    };
   };
+
+  systemd.services.NetworkManager-ensure-profiles.serviceConfig =
+    let
+      profiles = lib.mapAttrs (name: ini.generate (lib.escapeShellArg name)) cfg.ensureProfiles.profiles;
+    in
+    {
+      LoadCredentialEncrypted = [ "personal-wifi-passwords" ];
+
+      # Since systemd doesn't support reading `EnvironmentFile` from a
+      # cred, we replace the full thing with our own code.
+      ExecStart = lib.mkForce (
+        pkgs.writers.writeNu "ensure-profiles"
+          {
+            makeWrapperArgs = [
+              "--prefix"
+              "PATH"
+              ":"
+              "${lib.makeBinPath [ cfg.package ]}"
+            ];
+          }
+          ''
+            mkdir /run/NetworkManager/system-connections
+
+            let profiles = '${builtins.toJSON profiles}' | from json
+            let passwords = open --raw $'($env.CREDENTIALS_DIRECTORY)/personal-wifi-passwords' | from json
+
+            (
+              $profiles | items {|name template|
+                $passwords | items {|password substitute|
+                  (
+                    open --raw $template
+                    | str replace --all $'%($password)%' $substitute
+                    | save -f $'/run/NetworkManager/system-connections/($name).nmconnection'
+                  )
+                }
+              }
+            )
+
+            nmcli connection reload
+          ''
+      );
+    };
+
+  system.preSwitchChecks.ensureWifiPasswordsFileExists = ''
+    # This isn't actually a mistake here, but in the way the file gets
+    # stitched together.
+    #
+    # shellcheck disable=SC2234
+    test -e /etc/credstore.encrypted/personal-wifi-passwords
+  '';
 }


### PR DESCRIPTION
NetworkManager seems to fail to bring up bond networks on boot since NixOS 25.11. After bringing down the bond network and re-starting `ethernet`, everything works fine.

This commit just adds back the network, no idea why it's broken.